### PR TITLE
Display better Gnuplot errors, add macOS Gnuplot installation instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,5 @@ gem 'rspec'
 # install FFI.
 gem 'mb-sound-jackffi', '>= 0.0.15.usegit', github: 'mike-bourgeous/mb-sound-jackffi.git'
 
-gem 'mb-math', github: 'mike-bourgeous/mb-math.git'
-gem 'mb-util', github: 'mike-bourgeous/mb-util.git'
+gem 'mb-math', '>= 0.1.7.3.usegit', github: 'mike-bourgeous/mb-math.git'
+gem 'mb-util', '>= 0.1.12.usegit', github: 'mike-bourgeous/mb-util.git'

--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,4 @@ gem 'rspec'
 gem 'mb-sound-jackffi', '>= 0.0.15.usegit', github: 'mike-bourgeous/mb-sound-jackffi.git'
 
 gem 'mb-math', '>= 0.1.7.3.usegit', github: 'mike-bourgeous/mb-math.git'
-gem 'mb-util', '>= 0.1.12.usegit', github: 'mike-bourgeous/mb-util.git'
+gem 'mb-util', '>= 0.1.13.1.usegit', github: 'mike-bourgeous/mb-util.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,9 +17,9 @@ GIT
 
 GIT
   remote: https://github.com/mike-bourgeous/mb-util.git
-  revision: 544849c40ef24b53ded7dde744fad4352b1542bd
+  revision: 1ef62b50381e8b6d16af38c3ce120626780aae53
   specs:
-    mb-util (0.1.12.usegit)
+    mb-util (0.1.13.1.usegit)
 
 PATH
   remote: .
@@ -92,7 +92,7 @@ DEPENDENCIES
   mb-math (>= 0.1.7.3.usegit)!
   mb-sound!
   mb-sound-jackffi (>= 0.0.15.usegit)!
-  mb-util (>= 0.1.12.usegit)!
+  mb-util (>= 0.1.13.1.usegit)!
   numo-narray
   pry
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/mike-bourgeous/mb-math.git
-  revision: e182bca71f4eb4f98b341545df017bab7e2ea4ad
+  revision: 4c3974c99d22b2c76b8b0efb116cf857feffbc3a
   specs:
-    mb-math (0.1.4.1.usegit)
+    mb-math (0.1.7.3.usegit)
       cmath (~> 1.0.0)
       mb-util (>= 0.1.0.usegit)
       numo-narray (~> 0.9.1)
@@ -17,9 +17,9 @@ GIT
 
 GIT
   remote: https://github.com/mike-bourgeous/mb-util.git
-  revision: 5616cc4ce6218b5c541242ac47b0c99a30952a6c
+  revision: 544849c40ef24b53ded7dde744fad4352b1542bd
   specs:
-    mb-util (0.1.7.1.usegit)
+    mb-util (0.1.12.usegit)
 
 PATH
   remote: .
@@ -89,10 +89,10 @@ PLATFORMS
 DEPENDENCIES
   builder (~> 3.2.4)
   cmath
-  mb-math!
+  mb-math (>= 0.1.7.3.usegit)!
   mb-sound!
   mb-sound-jackffi (>= 0.0.15.usegit)!
-  mb-util!
+  mb-util (>= 0.1.12.usegit)!
   numo-narray
   pry
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ There are some base packages you'll need first:
 ```bash
 # Debian-/Ubuntu-based Linux (macOS/Arch/CentOS will differ)
 sudo apt-get install ffmpeg gnuplot-qt
+
+# macOS (with Homebrew)
+brew install ffmpeg gnuplot
 ```
 
 Then you'll want to install Ruby 2.7.2.

--- a/bin/play.rb
+++ b/bin/play.rb
@@ -5,4 +5,9 @@ require 'bundler/setup'
 require 'pry-byebug'
 require 'mb-sound'
 
+if ARGV.include?('--help') || ARGV.empty?
+  puts "Usage: \e[1m#{$0}\e[0m sound_filename"
+  exit 1
+end
+
 MB::Sound.play ARGV[0]

--- a/bin/sound.rb
+++ b/bin/sound.rb
@@ -74,5 +74,8 @@ Pry.pry(
     -> (obj, nest, pry) {
       ' ' * _pry_a.call(obj, nest, pry).gsub(/(\x01|\x02|\e\[[0-9;]*[A-Za-z])/, '').length
     }
-  ])
+  ]),
+  exception_handler: ->(output, exception, _pry) {
+    output.puts(MB::U.highlight(exception))
+  }
 )

--- a/bin/sound.rb
+++ b/bin/sound.rb
@@ -76,6 +76,6 @@ Pry.pry(
     }
   ]),
   exception_handler: ->(output, exception, _pry) {
-    output.puts(MB::U.highlight(exception))
+    output.puts(MB::U.color_trace(exception, exclude: %r{/pry-.*/lib/pry}))
   }
 )


### PR DESCRIPTION
Also significantly improved formatting of exceptions in the `bin/sound.rb` console:

Before: ![image](https://user-images.githubusercontent.com/5015814/142266116-aff66752-0894-4587-bd04-363a7cc97ad2.png)

After: ![image](https://user-images.githubusercontent.com/5015814/142265923-cb9bc5b8-89ec-4bdc-bd5a-bcf7e424dfab.png)

Fixes #18

Fixes #19 
