### PR TITLE
Add a grain repeater / stutter effect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,18 +11,9 @@ gem 'rake', '~> 13.0.1'
 gem 'cmath'
 gem 'numo-narray'
 
-# Interactive command line gems
-gem 'pry', '~> 0.13.0'
-gem 'pry-byebug'
-gem 'pry-doc'
-gem 'word_wrap'
-
-# Testing gems
-gem 'rspec'
-
 # Comment this out if you don't want to use Jack via FFI or don't want to
 # install FFI.
 gem 'mb-sound-jackffi', '>= 0.0.19.usegit', github: 'mike-bourgeous/mb-sound-jackffi.git'
 
-gem 'mb-math', '>= 0.1.14.usegit', github: 'mike-bourgeous/mb-math.git'
-gem 'mb-util', '>= 0.1.16.usegit', github: 'mike-bourgeous/mb-util.git'
+gem 'mb-math', '>= 0.2.1.usegit', github: 'mike-bourgeous/mb-math.git'
+gem 'mb-util', '>= 0.1.21.usegit', github: 'mike-bourgeous/mb-util.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     docile (1.4.1)
     ffi (1.13.1)
     forwardable (1.3.3)
+    getoptlong (0.2.1)
     matrix (0.4.2)
     method_source (1.1.0)
     midi-message (0.4.9)
@@ -102,6 +103,7 @@ DEPENDENCIES
   builder (~> 3.2.4)
   cmath
   forwardable (~> 1.3.3)
+  getoptlong (~> 0.2.1)
   mb-math (>= 0.2.1.usegit)!
   mb-sound!
   mb-sound-jackffi (>= 0.0.19.usegit)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,15 @@
 GIT
   remote: https://github.com/mike-bourgeous/mb-math.git
-  revision: d91920d53c625db0f54d1010f1dd70132d2d021a
+  revision: cd3c3751a4f82039531bc48c06284fddcb8a38ea
   specs:
-    mb-math (0.1.14.usegit)
+    mb-math (0.2.1.usegit)
+      bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
-      mb-util (>= 0.1.0.usegit)
+      matrix (~> 0.4.2)
+      mb-util (>= 0.1.20.usegit)
       numo-narray (~> 0.9.1)
+      numo-pocketfft (~> 0.4.1)
+      prime (~> 0.1.3)
 
 GIT
   remote: https://github.com/mike-bourgeous/mb-sound-jackffi.git
@@ -17,25 +21,26 @@ GIT
 
 GIT
   remote: https://github.com/mike-bourgeous/mb-util.git
-  revision: 71ef73cba4912c25197e3930e9def2f5124399c8
+  revision: f52d4db34a644b12a5d4c0bcabefa61ff966181c
   specs:
-    mb-util (0.1.16.usegit)
+    mb-util (0.1.21.usegit)
 
 PATH
   remote: .
   specs:
     mb-sound (0.7.1.usegit)
       cmath (~> 1.0.0)
-      mb-math (>= 0.1.14.usegit)
-      mb-util (>= 0.1.16.usegit)
+      mb-math (>= 0.2.1.usegit)
+      mb-util (>= 0.1.21.usegit)
       midi-nibbler (~> 0.2.4)
       midilib (~> 4.0.0)
       numo-narray (~> 0.9.1.8)
-      numo-pocketfft (~> 0.2.2)
+      numo-pocketfft (~> 0.4.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    bigdecimal (3.1.8)
     builder (3.2.4)
     byebug (11.1.3)
     cmath (1.0.0)
@@ -43,20 +48,25 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.1)
     ffi (1.13.1)
+    forwardable (1.3.3)
+    matrix (0.4.2)
     method_source (1.1.0)
     midi-message (0.4.9)
     midi-nibbler (0.2.4)
       midi-message (~> 0.4, >= 0.4.4)
     midilib (4.0.2)
     numo-narray (0.9.1.9)
-    numo-pocketfft (0.2.2)
-      numo-narray (~> 0.9.1)
+    numo-pocketfft (0.4.1)
+      numo-narray (>= 0.9.1)
+    prime (0.1.3)
+      forwardable
+      singleton
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+      pry (~> 0.13.0)
     pry-doc (1.5.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
@@ -75,14 +85,14 @@ GEM
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
+    rspec-support (3.13.2)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
-    word_wrap (1.0.0)
+    singleton (0.3.0)
     yard (0.9.37)
 
 PLATFORMS
@@ -91,19 +101,19 @@ PLATFORMS
 DEPENDENCIES
   builder (~> 3.2.4)
   cmath
-  mb-math (>= 0.1.14.usegit)!
+  forwardable (~> 1.3.3)
+  mb-math (>= 0.2.1.usegit)!
   mb-sound!
   mb-sound-jackffi (>= 0.0.19.usegit)!
-  mb-util (>= 0.1.16.usegit)!
+  mb-util (>= 0.1.21.usegit)!
   numo-narray
-  pry (~> 0.13.0)
-  pry-byebug
+  pry (~> 0.13.1)
+  pry-byebug (~> 3.9.0)
   pry-doc
   rake (~> 13.0.1)
   rake-compiler (~> 1.1.1)
   rspec
   simplecov (~> 0.21.2)
-  word_wrap
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     singleton (0.3.0)
+    word_wrap (1.0.0)
     yard (0.9.37)
 
 PLATFORMS
@@ -116,6 +117,7 @@ DEPENDENCIES
   rake-compiler (~> 1.1.1)
   rspec
   simplecov (~> 0.21.2)
+  word_wrap (~> 1.0.0)
 
 BUNDLED WITH
    2.1.4

--- a/bin/grain_repeater.rb
+++ b/bin/grain_repeater.rb
@@ -7,6 +7,7 @@
 # Examples:
 #     $0 --delay=0.02083333 --count=8 sounds/drums.flac
 #     $0 --delay=0.05 --count=8 sounds/synth0.flac
+#     $0 --delay=0.5 --count=2 sounds/sine/log_sweep_20_20k.flac
 
 require 'bundler/setup'
 

--- a/bin/grain_repeater.rb
+++ b/bin/grain_repeater.rb
@@ -1,8 +1,12 @@
 #!/usr/bin/env ruby
 # Very simple granular delay repeater.
 # (C)2024 Mike Bourgeous
+#
+# Usage: $0 [--help] [--delay=seconds] [--count=integer]
 
 require 'bundler/setup'
+
+require 'getoptlong'
 
 require 'mb/sound'
 
@@ -18,8 +22,34 @@ require 'mb/sound'
 #    signals using a square wave.
 
 # Parameters:
-# - Grain size
+# - Grain size / delay size
 # - Number of repeats
 # - Stereo spread?
 
+opts = GetoptLong.new(
+  [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
+  [ '--delay', '-d', GetoptLong::REQUIRED_ARGUMENT ],
+  [ '--count', '-c', GetoptLong::REQUIRED_ARGUMENT ],
+)
 
+delay = 0.125
+count = 2
+opts.each do |opt, arg|
+  case opt
+  when '--help'
+    MB::U.print_header_comment
+    exit 1
+
+  when '--delay'
+    delay = arg.to_f
+    raise 'delay must be positive' unless delay > 0
+
+  when '--count'
+    count = arg.to_i
+    raise NotImplementedError, 'Only a count of 2 is supported at this time' unless count == 2
+  end
+end
+
+puts MB::U.highlight({count: count, delay: delay})
+puts "\e[1;31mTODO\e[0m"
+exit 1

--- a/bin/grain_repeater.rb
+++ b/bin/grain_repeater.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# Very simple granular delay repeater.
+# (C)2024 Mike Bourgeous
+
+require 'bundler/setup'
+
+require 'mb/sound'
+
+# The idea is to have every other N samples play live, followed by the same N
+# samples delayed.
+#
+# Some possible ways to go about this:
+# 1. Use an ordinary delay line and a square wave or stepped oscillator to
+#    control the delay time.
+# 2. Build a granular-specific delay buffer that can be told to start playing a
+#    grain at a specific point in past absolute time, or something like that.
+# 3. Use a fixed-time delay and modulate the amplitude of the wet and dry
+#    signals using a square wave.
+
+# Parameters:
+# - Grain size
+# - Number of repeats
+# - Stereo spread?
+
+

--- a/bin/grain_repeater.rb
+++ b/bin/grain_repeater.rb
@@ -99,14 +99,23 @@ puts MB::U.highlight(
 # TODO: rate needs to scale based on count
 rate = 0.5 / delay
 
-paths = input_nodes.map { |inp|
+paths = input_nodes.map.with_index { |inp, idx|
   # TODO: cross-fade two delays with opposite phase instead of fading out and back in
   fade_osc = (rate * 2).hz.sine.at(0..500).with_phase(-Math::PI / 2).clip(0, 1)
 
   # TODO: multiple repeats: rate.hz.with_phase(Math::PI).ramp.at(0..1).proc { |v| v.map { |q| (q * (count).floor / (count - 1.0) }
   delay_osc = rate.hz.square.at(0..delay).with_phase(Math::PI)
 
-  inp.delay(seconds: delay_osc, smoothing: false) * fade_osc
+  case idx
+  when 0
+    inp.delay(seconds: delay_osc, smoothing: false) * fade_osc
+
+  when 1
+    fade_osc
+
+  when 2
+    delay_osc
+  end
 }
 
 loop do

--- a/bin/grain_repeater.rb
+++ b/bin/grain_repeater.rb
@@ -3,6 +3,10 @@
 # (C)2024 Mike Bourgeous
 #
 # Usage: $0 [--help] [--delay=seconds] [--count=integer] [--channels=integer] [--output=filename] [filename]
+#
+# Examples:
+#     $0 --delay=0.02083333 --count=8 sounds/drums.flac
+#     $0 --delay=0.05 --count=8 sounds/synth0.flac
 
 require 'bundler/setup'
 

--- a/bin/grain_repeater.rb
+++ b/bin/grain_repeater.rb
@@ -36,7 +36,7 @@ opts = GetoptLong.new(
 
 delay = 0.125
 count = 2
-channels = ENV['CHANNELS']&.to_i || 2
+channels = ENV['CHANNELS']&.to_i
 output_filename = nil
 
 opts.each do |opt, arg|
@@ -67,9 +67,11 @@ end
 filename = ARGV[0]
 if filename
   raise "Cannot read #{filename}" unless File.readable?(filename)
-  input = MB::Sound.file_input(filename)
+  input = MB::Sound.file_input(filename, channels: channels)
+  channels = input.channels
   input_nodes = input.split
 else
+  channels ||= 2
   input = MB::Sound.input(channels: channels)
   input_nodes = input.split
 end

--- a/bin/grain_repeater.rb
+++ b/bin/grain_repeater.rb
@@ -50,6 +50,25 @@ opts.each do |opt, arg|
   end
 end
 
-puts MB::U.highlight({count: count, delay: delay})
+filename = ARGV[0]
+if filename
+  raise "Cannot read #{filename}" unless File.readable?(filename)
+  input = MB::Sound.file_input(filename)
+  input_nodes = input.split
+else
+  input = MB::Sound.input(channels ENV['CHANNELS']&.to_i || 2)
+  input_nodes = input.split
+end
+
+output = MB::Sound.output(channels: inputs.length)
+
+puts MB::U.highlight({count: count, delay: delay, input: })
+
+
+rate = 1.0 / delay
+# Delay oscillator
+# rate.hz.square.at(0..delay).with_phase(Math::PI)
+
+
 puts "\e[1;31mTODO\e[0m"
 exit 1

--- a/bin/sound.rb
+++ b/bin/sound.rb
@@ -8,6 +8,7 @@ require 'bundler/setup'
 require 'benchmark'
 
 require 'io/console'
+require 'pry-byebug'
 
 Bundler.require
 

--- a/lib/mb/sound/graph_node.rb
+++ b/lib/mb/sound/graph_node.rb
@@ -173,6 +173,21 @@ module MB
         MB::Sound::GraphNode::ComplexNode.new(self, mode: :arg)
       end
 
+      # Truncates values from the node to the next lower integer.
+      def floor
+        self.proc(&:floor)
+      end
+
+      # Raises values from the node to the next higher integer.
+      def ceil
+        self.proc(&:ceil)
+      end
+
+      # Rounds values from the node to the nearest integer.
+      def round
+        self.proc(&:round)
+      end
+
       # Uses this node as the frequency value for an oscillator.
       def tone
         MB::Sound::Tone[self]

--- a/lib/mb/sound/graph_node.rb
+++ b/lib/mb/sound/graph_node.rb
@@ -328,7 +328,7 @@ module MB
       #
       # See MB::Sound::Filter::Delay#initialize for a description of the
       # +:smoothing+ parameter.
-      def delay(seconds: nil, samples: nil, rate: 48000, smoothing: true)
+      def delay(seconds: nil, samples: nil, rate: 48000, smoothing: true, max_delay: 1.0)
         if samples
           samples = samples.to_f if samples.is_a?(Numeric)
           seconds = samples / rate
@@ -336,7 +336,7 @@ module MB
           seconds = seconds.to_f if seconds.is_a?(Numeric)
         end
 
-        filter(MB::Sound::Filter::Delay.new(delay: seconds, rate: rate, smoothing: smoothing))
+        filter(MB::Sound::Filter::Delay.new(delay: seconds, rate: rate, smoothing: smoothing, buffer_size: rate * max_delay))
       end
 
       # Adds a multi-tap delay with the given delay sources, returning an Array

--- a/lib/mb/sound/graph_node/tee.rb
+++ b/lib/mb/sound/graph_node/tee.rb
@@ -32,7 +32,7 @@ module MB
           # being sampled once.
           def sample(count)
             source_buf = @tee.internal_sample(self, count)
-            return nil if source_buf.nil?
+            return nil if source_buf.nil? || source_buf.empty?
 
             @type = source_buf.class
             update_buffer(count)
@@ -105,7 +105,7 @@ module MB
 
           @read_branches << branch
 
-          @buf ||= @source.sample(count)
+          @buf ||= @source.sample(count).yield_self { |b| MB::M.zpad(b, count) if b && !b.empty? }
         end
       end
     end

--- a/mb-sound.gemspec
+++ b/mb-sound.gemspec
@@ -54,5 +54,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake-compiler', '~> 1.1.1'
 
+  spec.add_development_dependency 'getoptlong', '~> 0.2.1'
   spec.add_development_dependency 'forwardable', '~> 1.3.3'
 end

--- a/mb-sound.gemspec
+++ b/mb-sound.gemspec
@@ -56,4 +56,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'getoptlong', '~> 0.2.1'
   spec.add_development_dependency 'forwardable', '~> 1.3.3'
+
+  spec.add_development_dependency 'word_wrap', '~> 1.0.0'
 end

--- a/mb-sound.gemspec
+++ b/mb-sound.gemspec
@@ -31,22 +31,28 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'cmath', '~> 1.0.0'
   spec.add_runtime_dependency 'numo-narray', '~> 0.9.1.8'
-  spec.add_runtime_dependency 'numo-pocketfft', '~> 0.2.2'
+  spec.add_runtime_dependency 'numo-pocketfft', '~> 0.4.1'
 
   spec.add_runtime_dependency 'midi-nibbler', '~> 0.2.4'
 
   spec.add_runtime_dependency 'midilib', '~> 4.0.0'
 
-  spec.add_runtime_dependency 'mb-math', '>= 0.1.14.usegit'
-  spec.add_runtime_dependency 'mb-util', '>= 0.1.16.usegit'
+  spec.add_runtime_dependency 'mb-math', '>= 0.2.1.usegit'
+  spec.add_runtime_dependency 'mb-util', '>= 0.1.21.usegit'
 
   # For generating MIDI controller templates for ACID
   spec.add_development_dependency 'builder', '~> 3.2.4'
 
+  # Interactive command line gems
   spec.add_development_dependency 'pry', '~> 0.13.1'
   spec.add_development_dependency 'pry-byebug', '~> 3.9.0'
+  spec.add_development_dependency 'pry-doc'
 
+  # Testing gems
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov', '~> 0.21.2'
 
   spec.add_development_dependency 'rake-compiler', '~> 1.1.1'
+
+  spec.add_development_dependency 'forwardable', '~> 1.3.3'
 end

--- a/spec/lib/mb/sound/graph_node/tee_spec.rb
+++ b/spec/lib/mb/sound/graph_node/tee_spec.rb
@@ -27,4 +27,18 @@ RSpec.describe(MB::Sound::GraphNode::Tee) do
     expect(a2).to eq(b2)
     expect(ref).not_to eq(b2)
   end
+
+  it 'zero pads if the source returns less data' do
+    source = MB::Sound::ArrayInput.new(data: [Numo::SFloat[]])
+    expect(source).to receive(:sample).with(5).and_return(Numo::SFloat[1,2,3,4,5], Numo::SFloat[6,7])
+    allow(source).to receive(:tee).and_call_original
+
+    t1, t2 = source.tee
+
+    t1.sample(5)
+    t2.sample(5)
+
+    expect(t1.sample(5)).to eq(Numo::SFloat[6,7,0,0,0])
+    expect(t2.sample(5)).to eq(Numo::SFloat[6,7,0,0,0])
+  end
 end

--- a/spec/lib/mb/sound/graph_node_spec.rb
+++ b/spec/lib/mb/sound/graph_node_spec.rb
@@ -195,6 +195,32 @@ RSpec.describe(MB::Sound::GraphNode) do
     end
   end
 
+  context 'rounding and truncation methods' do
+    let(:data) { Numo::SFloat[-1.9, -1.1, -0.7, -0.3, 0.3, 0.7, 1.1, 1.9] }
+    let(:node) { MB::Sound::ArrayInput.new(data: [data]) }
+
+    describe '#floor' do
+      it 'rounds down to integers' do
+        g = node.floor
+        expect(g.sample(data.length)).to eq(Numo::SFloat[-2, -2, -1, -1, 0, 0, 1, 1])
+      end
+    end
+
+    describe '#ceil' do
+      it 'rounds up to integers' do
+        g = node.ceil
+        expect(g.sample(data.length)).to eq(Numo::SFloat[-1, -1, -0, -0, 1, 1, 2, 2])
+      end
+    end
+
+    describe '#round' do
+      it 'rounds to the nearest integer' do
+        g = node.round
+        expect(g.sample(data.length)).to eq(Numo::SFloat[-2, -1, -1, 0, 0, 1, 1, 2])
+      end
+    end
+  end
+
   describe '#softclip' do
     it 'can apply softclipping' do
       graph = (1.hz.square.at_rate(20).at(10) + 9.75).softclip(0.5, 1)


### PR DESCRIPTION
This is a one-night project to write a simple stutter effect or grain repeater.  It chops the audio into slices of a given length and repeats that slice a given number of times, then jumps ahead to the current time and repeats that slice, etc., so the output length is the same as the input length (with some possible zero padding for buffer sizes).

```bash
bin/grain_repeater.rb sounds/sine/log_sweep_20_20k.flac
```