### PR TITLE
Buffer adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
-
-gem 'rake', '~> 13.0.1'
-
-# Math gems
-gem 'cmath'
-gem 'numo-narray'
 
 # Comment this out if you don't want to use Jack via FFI or don't want to
 # install FFI.
 gem 'mb-sound-jackffi', '>= 0.0.19.usegit', github: 'mike-bourgeous/mb-sound-jackffi.git'
 
-gem 'mb-math', '>= 0.2.1.usegit', github: 'mike-bourgeous/mb-math.git'
+gem 'mb-math', '>= 0.2.2.usegit', github: 'mike-bourgeous/mb-math.git'
 gem 'mb-util', '>= 0.1.21.usegit', github: 'mike-bourgeous/mb-util.git'

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ gem 'cmath'
 gem 'numo-narray'
 
 # Interactive command line gems
-gem 'pry', '~> 0.13.0'
-gem 'pry-byebug'
 gem 'pry-doc'
 gem 'word_wrap'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/mike-bourgeous/mb-math.git
-  revision: cd3c3751a4f82039531bc48c06284fddcb8a38ea
+  revision: 4d1d0c165821f03ea1223acb6a304d5f6c7c2187
   specs:
-    mb-math (0.2.1.usegit)
+    mb-math (0.2.2.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)
-      mb-util (>= 0.1.20.usegit)
-      numo-narray (~> 0.9.1)
+      mb-util (>= 0.1.21.usegit)
+      numo-narray (~> 0.9.2.1)
       numo-pocketfft (~> 0.4.1)
       prime (~> 0.1.3)
 
@@ -30,17 +30,17 @@ PATH
   specs:
     mb-sound (0.7.1.usegit)
       cmath (~> 1.0.0)
-      mb-math (>= 0.2.1.usegit)
+      mb-math (>= 0.2.2.usegit)
       mb-util (>= 0.1.21.usegit)
       midi-nibbler (~> 0.2.4)
       midilib (~> 4.0.0)
-      numo-narray (~> 0.9.1.8)
+      numo-narray (~> 0.9.2)
       numo-pocketfft (~> 0.4.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     builder (3.2.4)
     byebug (11.1.3)
     cmath (1.0.0)
@@ -56,7 +56,7 @@ GEM
     midi-nibbler (0.2.4)
       midi-message (~> 0.4, >= 0.4.4)
     midilib (4.0.2)
-    numo-narray (0.9.1.9)
+    numo-narray (0.9.2.1)
     numo-pocketfft (0.4.1)
       numo-narray (>= 0.9.1)
     prime (0.1.3)
@@ -102,14 +102,13 @@ PLATFORMS
 
 DEPENDENCIES
   builder (~> 3.2.4)
-  cmath
+  bundler (= 2.4.22)
   forwardable (~> 1.3.3)
   getoptlong (~> 0.2.1)
-  mb-math (>= 0.2.1.usegit)!
+  mb-math (>= 0.2.2.usegit)!
   mb-sound!
   mb-sound-jackffi (>= 0.0.19.usegit)!
   mb-util (>= 0.1.21.usegit)!
-  numo-narray
   pry (~> 0.13.1)
   pry-byebug (~> 3.9.0)
   pry-doc
@@ -120,4 +119,4 @@ DEPENDENCIES
   word_wrap (~> 1.0.0)
 
 BUNDLED WITH
-   2.1.4
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,9 +54,9 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+      pry (~> 0.13.0)
     pry-doc (1.5.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
@@ -96,8 +96,8 @@ DEPENDENCIES
   mb-sound-jackffi (>= 0.0.19.usegit)!
   mb-util (>= 0.1.16.usegit)!
   numo-narray
-  pry (~> 0.13.0)
-  pry-byebug
+  pry (~> 0.13.1)
+  pry-byebug (~> 3.9.0)
   pry-doc
   rake (~> 13.0.1)
   rake-compiler (~> 1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-sound (0.7.1.usegit)
+    mb-sound (0.8.0.usegit)
       cmath (~> 1.0.0)
       mb-math (>= 0.2.2.usegit)
       mb-util (>= 0.1.21.usegit)

--- a/bin/flanger.rb
+++ b/bin/flanger.rb
@@ -19,14 +19,14 @@
 #    Water drums: SMOOTHING=4 WET=1 DRY=0 $0 sounds/drums.flac 0.02 -0.3 46 6
 #    Space warp: SMOOTHING=10 WET=1 DRY=0 $0 sounds/drums.flac 0.2 -0.8 15 6
 #    Time warp: WET=1 DRY=0 $0 sounds/drums.flac 0.2 -0.8 0.3 6
-#    Bass comb: SMOOTHING=0.7 DRY=0 bin/flanger.rb sounds/drums.flac 0.04 0.95 150 1
+#    Bass comb: SMOOTHING=0.7 DRY=0 $0 sounds/drums.flac 0.04 0.95 150 1
 
 require 'bundler/setup'
 
 require 'mb/sound'
 
 if ARGV.include?('--help')
-  puts MB::U.read_header_comment.join.gsub('$0', "\e[1m#{$0}\e[0m")
+  MB::U.print_header_help
   exit 1
 end
 

--- a/bin/flanger.rb
+++ b/bin/flanger.rb
@@ -12,6 +12,9 @@
 #    WET - wet output level (default 1)
 #    SPREAD - LFO phase spread across channels (default 180)
 #
+# Examples:
+#    DRY=0.5 $0 sounds/drums.flac 0.002 0.85 0.2 0.5
+#
 # Cool effects (omit filename for realtime processing from Jack):
 #    Arpeggio: SMOOTHING=0.5 $0 sounds/transient_synth.flac 0.035 0 3 2
 #    Slow arp: SMOOTHING=1.5 $0 sounds/transient_synth.flac 0.15 0 3 2
@@ -20,6 +23,9 @@
 #    Space warp: SMOOTHING=10 WET=1 DRY=0 $0 sounds/drums.flac 0.2 -0.8 15 6
 #    Time warp: WET=1 DRY=0 $0 sounds/drums.flac 0.2 -0.8 0.3 6
 #    Bass comb: SMOOTHING=0.7 DRY=0 $0 sounds/drums.flac 0.04 0.95 150 1
+#    Bass beat: SPREAD=10 $0 sounds/drums.flac 0.006 -0.98 0.4 2
+#    Gritty overtone: DRY=0.5 $0 sounds/synth0.flac 0.0029 0.85 60 0.1
+#    Decimation: DRY=0 $0 sounds/synth0.flac 0.0058 -0.85 3300 0.2
 
 require 'bundler/setup'
 
@@ -90,7 +96,7 @@ else
 end
 
 bufsize = output.buffer_size
-internal_bufsize = 48
+internal_bufsize = 24
 internal_bufsize -= 1 until bufsize % internal_bufsize == 0
 
 delay_samples = delay * output.rate

--- a/bin/multitap_delay.rb
+++ b/bin/multitap_delay.rb
@@ -5,6 +5,10 @@
 # This is inspired by a module I saw on Andrew Huang's YouTube channel.
 #
 # Usage: $0 [base_delay_seconds] [filename]
+#
+# Examples:
+#     Resonant widener: $0 0.001 sounds/transient_synth.flac
+#     Pinged filter drums: $0 0.2 sounds/drums.flac
 
 require 'bundler/setup'
 

--- a/bin/multitap_delay.rb
+++ b/bin/multitap_delay.rb
@@ -1,14 +1,17 @@
 #!/usr/bin/env ruby
 # A filtered multi-tap delay effect.
-# This is inspired by a module I saw on Andrew Huang's YouTube channel.
 # (C)2022 Mike Bourgeous
+#
+# This is inspired by a module I saw on Andrew Huang's YouTube channel.
+#
+# Usage: $0 [base_delay_seconds] [filename]
 
 require 'bundler/setup'
 
 require 'mb/sound'
 
 if ARGV.include?('--help')
-  puts "Usage: \e[1m#{$0}\e[0m [base_delay_s] [filename]"
+  MB::U.print_header_help
   exit 1
 end
 
@@ -21,7 +24,7 @@ base_delay_s ||= 0.1
 
 filename = others[0]
 if filename && File.readable?(filename)
-  inputs = MB::Sound.file_input(filename).split.map { |d| d.and_then(0.hz.at(0).for(delay * 4)) }
+  inputs = MB::Sound.file_input(filename).split.map { |d| d.and_then(0.hz.at(0).for(base_delay_s * 4)) }
 else
   inputs = MB::Sound.input(channels: ENV['CHANNELS']&.to_i || 2).split
 end

--- a/bin/reverse_delay.rb
+++ b/bin/reverse_delay.rb
@@ -1,13 +1,18 @@
 #!/usr/bin/env ruby
 # A reverse delay effect.  This works by playing a delay buffer in reverse.
 # (C)2022 Mike Bourgeous
+#
+# Usage: $0 [delay_s [feedback]] [filename]
+#
+# Examples:
+#     DRY=0 $0 0.2 0 sounds/drums.flac
 
 require 'bundler/setup'
 
 require 'mb/sound'
 
 if ARGV.include?('--help')
-  puts "Usage: \e[1m#{$0}\e[0m [delay_s [feedback]] [filename]"
+  MB::U.print_header_help
   exit 1
 end
 

--- a/bin/tape_delay.rb
+++ b/bin/tape_delay.rb
@@ -2,10 +2,23 @@
 # A simple, mono, tape-simulator echo with feedback.
 # (C)2022-2024 Mike Bourgeous
 #
-# Usage: [DRY=1.0] [WET=1.0] [PITCH=1] $0 [delay_s [feedback [extra_time]]] [filename]
+# Usage: [DRY=1.0] [WET=1.0] [DRIVE=1.0] [PITCH=1 [SMOOTHING=2]] $0 [delay_s [feedback [extra_time]]] [filename]
 #
 # Examples:
-#     $0
+#     # synth groove
+#     DRY=1.75 DRIVE=2 WET=1.5 $0 0.25 1 sounds/transient_synth.flac
+#
+#     # space ship
+#     DRY=0.4 WET=1.2 $0 0.25 1.06 sounds/sine/log_sweep_20_20k.flac
+#
+#     # lo-fi crunch
+#     DRY=0 DRIVE=100 $0 0 0 sounds/drums.flac
+#
+#     # broken time machine
+#     DRY=0 SMOOTHING=0.1 PITCH=1 $0 0.3333333 1.15 sounds/drums.flac
+#
+#     # dub drums
+#     DRIVE=10 $0 0.166667 1.14 sounds/drums.flac
 
 require 'bundler/setup'
 
@@ -40,9 +53,9 @@ if filename && File.readable?(filename)
   input = MB::Sound.file_input(filename)
   input_buffer_size = input.buffer_size
 
-  input = input.and_then(0.hz.at(0).for(extra))
+  input = input.and_then(0.hz.at(0).for(extra)).named(filename)
 else
-  input = MB::Sound.input(channels: 1)
+  input = MB::Sound.input(channels: 1).named('audio input')
   input_buffer_size = input.buffer_size
 end
 
@@ -56,50 +69,71 @@ if ENV['PITCH'] == '1'
   delay_samples = delay_samples + -0.4.hz.ramp.forever.at(0..3250)
 end
 
-puts MB::U.highlight(
-  delay: delay,
-  feedback: feedback,
-  input: input.graph_node_name,
-  rate: output.rate,
-  buffer: bufsize,
-  extra_time: extra
-)
-
-# TODO: Make it easy to replicate a signal graph for each of N channels
-
 internal_bufsize = 16
 
 dry = ENV['DRY']&.to_f || 1
 wet = ENV['WET']&.to_f || 1
+drive = ENV['DRIVE']&.to_f || 1
 smoothing = ENV['SMOOTHING']&.to_f || 2
+
+puts MB::U.highlight(
+  dry: dry,
+  wet: wet,
+  drive: drive,
+  smoothing: smoothing,
+  delay: delay,
+  feedback: feedback,
+  extra_time: extra,
+  input: input.graph_node_name,
+  rate: output.rate,
+  buffer: bufsize,
+  internal_buffer: internal_bufsize,
+)
+
+# TODO: Make it easy to replicate a signal graph for each of N channels
+# TODO: stereo+, ping-pong
 
 begin
   # Use the input buffer size when reading from the input, so our feedback loop
   # can run with a different buffer size.
   # TODO: maybe this should be automatic
-  inp, inp_dry = input.with_buffer(input_buffer_size).named('Input').tee
+  inp, inp_dry = input.with_buffer(input_buffer_size).named(filename || 'audio in').tee
+  inp.named('pre-delay input')
+  inp_dry.named('dry output')
 
   # Feedback buffer, overwritten by a later call to #spy
   a = Numo::SFloat.zeros(internal_bufsize)
 
   # Feedback injector and delay
   adjusted_delay = (delay_samples - internal_bufsize.constant).clip(0, nil)
-  b = (inp + 0.constant.proc { a }).delay(samples: adjusted_delay, smoothing: smoothing)
+  b = (inp * drive + 0.constant.proc { a } * feedback).delay(samples: adjusted_delay, smoothing: smoothing)
 
   # Tape saturator
-  c = b.filter(200.hz.highpass(quality: 0.5)).filter(3000.hz.lowpass(quality: 0.5))
-  d = c.softclip(0, 0.5)
+  c = b
+    .filter(200.hz.highpass(quality: 0.5))
+    .filter(3000.hz.lowpass(quality: 0.5))
+    .softclip(0, 0.5)
+    .named('tape sim')
 
-  # Final output, with a spy to save feedback buffer, using a shorter buffer
-  # size for the feedback loop, allowing shorter delays
-  feedback_loop = (dry * inp_dry + wet * d * feedback)
-    .softclip(0.75, 0.95)
+  # Feedback, with a spy to save feedback buffer, using a shorter buffer size
+  # for the feedback loop, allowing shorter delays
+  feedback_loop = c
     .spy { |z| a[] = z if z }
+    .named('feedback')
+
+  # Final output
+  result = (dry * inp_dry + wet * feedback_loop)
+    .softclip(0.75, 0.95)
     .with_buffer(internal_bufsize)
+    .named('mixed output')
+
+  File.write('/tmp/tape_delay.dot', result.graphviz)
+  `dot -Tpng:cairo /tmp/tape_delay.dot -o /tmp/tape_delay.png`
 
   loop do
-    data = feedback_loop.sample(output.buffer_size)
+    data = result.sample(output.buffer_size)
     break if data.nil?
+    data = MB::M.zpad(data, output.buffer_size) if data.length < output.buffer_size
     output.write([data] * output.channels)
   end
 

--- a/bin/tape_delay.rb
+++ b/bin/tape_delay.rb
@@ -1,13 +1,18 @@
 #!/usr/bin/env ruby
-# A simple echo with feedback, to demonstrate the signal graph DSL.
-# (C)2022 Mike Bourgeous
+# A simple, mono, tape-simulator echo with feedback.
+# (C)2022-2024 Mike Bourgeous
+#
+# Usage: [DRY=1.0] [WET=1.0] [PITCH=1] $0 [delay_s [feedback [extra_time]]] [filename]
+#
+# Examples:
+#     $0
 
 require 'bundler/setup'
 
 require 'mb/sound'
 
 if ARGV.include?('--help')
-  puts "Usage: [PITCH=1] \e[1m#{$0}\e[0m [delay_s [feedback [extra_time]]] [filename]"
+  MB::U.print_header_help
   exit 1
 end
 
@@ -31,15 +36,20 @@ if filename && File.readable?(filename)
     extra = 1.0 if extra <= 0
     extra = 10 if extra > 10
   end
-  input = MB::Sound.file_input(filename).and_then(0.hz.at(0).for(extra))
+
+  input = MB::Sound.file_input(filename)
+  input_buffer_size = input.buffer_size
+
+  input = input.and_then(0.hz.at(0).for(extra))
 else
   input = MB::Sound.input(channels: 1)
+  input_buffer_size = input.buffer_size
 end
 
 output = MB::Sound.output
 bufsize = output.buffer_size
 
-delay_samples = (delay * output.rate - output.buffer_size)
+delay_samples = delay * output.rate
 delay_samples = 0 if delay_samples < 0
 
 if ENV['PITCH'] == '1'
@@ -57,22 +67,38 @@ puts MB::U.highlight(
 
 # TODO: Make it easy to replicate a signal graph for each of N channels
 
+internal_bufsize = 16
+
+dry = ENV['DRY']&.to_f || 1
+wet = ENV['WET']&.to_f || 1
+smoothing = ENV['SMOOTHING']&.to_f || 2
+
 begin
+  # Use the input buffer size when reading from the input, so our feedback loop
+  # can run with a different buffer size.
+  # TODO: maybe this should be automatic
+  inp, inp_dry = input.with_buffer(input_buffer_size).named('Input').tee
+
   # Feedback buffer, overwritten by a later call to #spy
-  a = Numo::SFloat.zeros(bufsize)
+  a = Numo::SFloat.zeros(internal_bufsize)
 
   # Feedback injector and delay
-  b = 0.hz.forever.proc { a }.delay(samples: delay_samples)
+  adjusted_delay = (delay_samples - internal_bufsize.constant).clip(0, nil)
+  b = (inp + 0.constant.proc { a }).delay(samples: adjusted_delay, smoothing: smoothing)
 
   # Tape saturator
   c = b.filter(200.hz.highpass(quality: 0.5)).filter(3000.hz.lowpass(quality: 0.5))
   d = c.softclip(0, 0.5)
 
-  # Final output, with a spy to save feedback buffer
-  f = (input + d * feedback).softclip(0.75, 0.95).spy { |z| a[] = z if z }
+  # Final output, with a spy to save feedback buffer, using a shorter buffer
+  # size for the feedback loop, allowing shorter delays
+  feedback_loop = (dry * inp_dry + wet * d * feedback)
+    .softclip(0.75, 0.95)
+    .spy { |z| a[] = z if z }
+    .with_buffer(internal_bufsize)
 
   loop do
-    data = f.sample(output.buffer_size)
+    data = feedback_loop.sample(output.buffer_size)
     break if data.nil?
     output.write([data] * output.channels)
   end

--- a/lib/mb/sound.rb
+++ b/lib/mb/sound.rb
@@ -118,6 +118,8 @@ module MB
   end
 end
 
+require_relative 'sound/buffer_helper'
+
 require_relative 'sound/graph_node'
 
 require_relative 'sound/io_base'

--- a/lib/mb/sound.rb
+++ b/lib/mb/sound.rb
@@ -119,7 +119,7 @@ module MB
 end
 
 require_relative 'sound/buffer_helper'
-
+require_relative 'sound/circular_buffer'
 require_relative 'sound/graph_node'
 
 require_relative 'sound/io_base'

--- a/lib/mb/sound.rb
+++ b/lib/mb/sound.rb
@@ -111,9 +111,10 @@ module MB
     # the interactive CLI).  A new Note object is created each time to allow
     # for modifications to old Notes and changes in global tuning.
     def self.const_missing(name)
+      super if name.to_s == 'Note'
       MB::Sound::Note.new(name)
     rescue ArgumentError
-      super(name)
+      super
     end
   end
 end

--- a/lib/mb/sound/adsr_envelope.rb
+++ b/lib/mb/sound/adsr_envelope.rb
@@ -47,6 +47,7 @@ module MB
     #     plotter.plot(envelope: total)
     class ADSREnvelope
       include GraphNode
+      include BufferHelper
 
       attr_reader :attack_time, :decay_time, :sustain_level, :release_time, :total, :peak, :time, :rate
 
@@ -168,7 +169,7 @@ module MB
       end
 
       def sample_count_c(count, filter: true)
-        setup_buffer(count)
+        setup_buffer(length: count)
 
         MB::FastSound.adsr_narray(
           @buf.inplace!,
@@ -287,13 +288,6 @@ module MB
       end
 
       private
-
-      # TODO: Maybe this should be some kind of helper mixin
-      def setup_buffer(length)
-        if @buf.nil? || @buf.length != length
-          @buf = Numo::SFloat.zeros(length)
-        end
-      end
 
       # Calculates internal parameters based on the given envelope parameters.
       # FIXME: envelopes come back to life or disappear abruptly if their times

--- a/lib/mb/sound/buffer_helper.rb
+++ b/lib/mb/sound/buffer_helper.rb
@@ -1,0 +1,70 @@
+module MB
+  module Sound
+    # This mixin provides the setup_buffer method for use by any class that
+    # needs an internal Numo::NArray buffer, and potentially needs to be able
+    # to convert that buffer from real to complex when data types change.
+    #
+    # Typical usage is to call #setup_buffer from a GraphNode's #sample
+    # method.
+    module BufferHelper
+      private
+
+      # Based on the given +length+ and whether to use +complex+ values,
+      # creates or replaces a buffer in @buf as needed.  If @buf already
+      # matches +length+ and +complex+, no change is made.
+      #
+      # If +temp+ is true, then another buffer of the same size and type is
+      # also created in @tmpbuf.
+      #
+      # If +:double+ is true, then double-precision buffers are used.
+      # Otherwise the method will create single-precision buffers.
+      def setup_buffer(length:, complex: false, temp: false, double: false)
+        # TODO: is this trying too hard to avoid a few conditionals by using
+        # too many conditionals?
+        return unless !defined?(@buf) || @buf.nil? ||
+          !defined?(@buflen) || @buflen != length ||
+          !defined?(@bufcomplex) || @bufcomplex != complex ||
+          !defined?(@buftemp) || @buftemp != temp ||
+          !defined?(@bufdouble) || @bufdouble != double ||
+          (temp && (!defined?(@tmpbuf) || @tmpbuf.nil?))
+
+        @buflen = length
+        @bufcomplex = complex
+        @buftemp = temp
+        @bufdouble = double
+
+        if double
+          @bufclass = complex ? Numo::DComplex : Numo::DFloat
+        else
+          @bufclass = complex ? Numo::SComplex : Numo::SFloat
+        end
+
+        if @buf.nil?
+          # Buffer doesn't exist; create it
+          @buf = @bufclass.zeros(length)
+        elsif @buf.length == length && @buf.class != @bufclass
+          # Buffer has the wrong type; cast it
+          @buf = @bufclass.cast(@buf)
+        elsif @buf.length < length
+          @buf = MB::M.zpad(@buf, length)
+        elsif @buf.length > length
+          @buf = @buf[0...length]
+        end
+
+        if temp
+          if @tmpbuf.nil?
+            # Buffer doesn't exist; create it
+            @tmpbuf = @bufclass.zeros(length)
+          elsif @tmpbuf.length == length && @tmpbuf.class != @bufclass
+            # Buffer has the wrong type; cast it
+            @tmpbuf = @bufclass.cast(@tmpbuf)
+          elsif @tmpbuf.length < length
+            @tmpbuf = MB::M.zpad(@tmpbuf, length)
+          elsif @tmpbuf.length > length
+            @tmpbuf = @tmpbuf[0...length]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mb/sound/buffer_helper.rb
+++ b/lib/mb/sound/buffer_helper.rb
@@ -32,6 +32,7 @@ module MB
         @bufcomplex = complex
         @buftemp = temp
         @bufdouble = double
+        @buf ||= nil
 
         if double
           @bufclass = complex ? Numo::DComplex : Numo::DFloat
@@ -52,6 +53,7 @@ module MB
         end
 
         if temp
+          @tmpbuf ||= nil
           if @tmpbuf.nil?
             # Buffer doesn't exist; create it
             @tmpbuf = @bufclass.zeros(length)

--- a/lib/mb/sound/buffer_helper.rb
+++ b/lib/mb/sound/buffer_helper.rb
@@ -62,11 +62,13 @@ module MB
         if b.nil?
           # Buffer doesn't exist; create it
           b = @bufclass.zeros(@buflen)
-        elsif b.length == @buflen && b.class != @bufclass
+        elsif b.class != @bufclass
           # Buffer has the wrong type; cast it
           # TODO: should we support demotion from Complex to Float?
           b = @bufclass.cast(b)
-        elsif b.length < @buflen
+        end
+
+        if b.length < @buflen
           # Buffer is too short; extend it with zeros
           b = MB::M.zpad(b, @buflen)
         elsif b.length > @buflen

--- a/lib/mb/sound/circular_buffer.rb
+++ b/lib/mb/sound/circular_buffer.rb
@@ -45,6 +45,9 @@ module MB
           raise BufferUnderflow, "Read of size #{count} is greater than #{@length} available samples"
         end
 
+        # Return an empty NArray if asked to read nothing, even if the buffer is empty
+        return @buf.class[] if count == 0
+
         MB::M.circular_read(@buf, @read_pos, count, target: @tmpbuf)[0...count].tap {
           @read_pos = (@read_pos + count) % @buffer_size
           @length -= count

--- a/lib/mb/sound/circular_buffer.rb
+++ b/lib/mb/sound/circular_buffer.rb
@@ -1,0 +1,74 @@
+module MB
+  module Sound
+    # A 1D circular buffer implemented around Numo::SFloat, Numo::DFloat,
+    # Numo::SComplex, or Numo::DComplex, supporting reads and writes of
+    # arbitrary sizes.
+    class CircularBuffer
+      include BufferHelper
+
+      # Thrown when more data is written than there is space for.
+      class BufferOverflow < RuntimeError; end
+
+      # Thrown when more data is read than has been written.
+      class BufferUnderflow < RuntimeError; end
+
+      # Maximum buffer size
+      attr_reader :buffer_size
+
+      # Number of values available for reading
+      attr_reader :length
+      alias count length
+
+      # Whether the buffer is real (false) or complex (true)
+      attr_reader :complex
+
+      # Whether the buffer is single-precision (false) or double-precision (true)
+      attr_reader :double
+
+      def initialize(buffer_size:, complex: false, double: false)
+        raise ArgumentError, 'Buffer size must be a positive integer' unless buffer_size.is_a?(Integer) && buffer_size > 0
+
+        @buffer_size = buffer_size.to_i
+        @complex = complex
+        @double = double
+
+        @read_pos = 0
+        @write_pos = 0
+        @length = 0
+
+        # TODO: call this again if any attributes change
+        setup_buffer(length: buffer_size, complex: complex, temp: true, double: double)
+      end
+
+      def read(count)
+        if count > @length
+          raise BufferUnderflow, "Read of size #{count} is greater than #{@length} available samples"
+        end
+
+        MB::M.circular_read(@buf, @read_pos, count, target: @tmpbuf)[0...count].tap {
+          @read_pos = (@read_pos + count) % @buffer_size
+          @length -= count
+        }
+      end
+
+      # Appends the given +narray+ to the circular buffer, returning the
+      # new count of available samples to read.
+      def write(narray)
+        # TODO: should the buffer grow automatically?
+        if narray.length > available
+          raise BufferOverflow, "Write of size #{narray.length} is greater than #{available} space available"
+        end
+
+        MB::M.circular_write(@buf, narray, @write_pos)
+        @write_pos = (@write_pos + narray.length) % @buffer_size
+        @length += narray.length
+      end
+
+      # Returns the available space left in the circular buffer.  See also
+      # #length.
+      def available
+        @buffer_size - @length
+      end
+    end
+  end
+end

--- a/lib/mb/sound/circular_buffer.rb
+++ b/lib/mb/sound/circular_buffer.rb
@@ -2,7 +2,24 @@ module MB
   module Sound
     # A 1D circular buffer implemented around Numo::SFloat, Numo::DFloat,
     # Numo::SComplex, or Numo::DComplex, supporting reads and writes of
-    # arbitrary sizes.
+    # arbitrary sizes.  Also supports multiple readers with different offsets,
+    # useful for fanout or delays.
+    #
+    # Single-reader example:
+    #
+    #     cbuf = MB::Sound::CircularBuffer.new(buffer_size: 100)
+    #     cbuf.write(Numo::SFloat[1,2,3])
+    #     cbuf.read(2) # => Numo::SFloat[1,2]
+    #
+    # Multi-reader example:
+    #
+    #     cbuf = MB::Sound::CircularBuffer.new(buffer_size: 100)
+    #     r1 = cbuf.reader
+    #     r2 = cbuf.reader
+    #     cbuf.write(Numo::SComplex[1i,2i,3i])
+    #     r1.read(2) # => Numo::SComplex[1i,2i]
+    #     r2.read(3) # => Numo::SComplex[1i,2i,3i]
+    #     r1.read(1) # => Numo::SComplex[3i]
     class CircularBuffer
       include BufferHelper
 
@@ -12,36 +29,63 @@ module MB
       # Thrown when more data is read than has been written.
       class BufferUnderflow < RuntimeError; end
 
-      # XXX multi-reader idea; see also GraphNode::MultitapDelay
-      class Reader
-        attr_reader :read_pos
+      # Thrown when #read is called after #reader, or vice versa.
+      class ReaderModeError < RuntimeError; end
 
-        def initialize(cbuf:, index:, read_pos:)
+      # Single reader with an independent read pointer as returned by #reader.
+      class Reader
+        include BufferHelper
+
+        # The number of samples available for reading from this Reader's
+        # position.
+        attr_reader :length
+        alias count length
+
+        # For internal use by CircularBuffer#reader.  Creates a new Reader at
+        # the given read position with the given initial length of available
+        # samples.
+        def initialize(cbuf:, index:, read_pos:, length:)
           @cbuf = cbuf
           @index = index
           @read_pos = read_pos
           @tmpbuf = nil
-        end
+          @length = length
 
-        def length
-          (@cbuf.write_pos - @read_pos) % @cbuf.buffer_size
+          setup_buffer(length: cbuf.buffer_size, complex: cbuf.complex, double: cbuf.double)
         end
 
         def read(count)
-          raise BufferUnderflow, "Reader #{@index} has #{length}, but #{count} requested" if count > length
+          # TODO: should we allow short reads (return less than requested)?
+          if count > @length
+            raise BufferUnderflow, "Read of size #{count} is greater than #{@length} available samples " \
+              "on #{@index < 0 ? 'default reader' : "reader #{@index}"}"
+          end
 
-          @cbuf.direct_read(pos: @read_pos, count: count, target: nil).tap {
+          setup_buffer(length: @cbuf.buffer_size, complex: @cbuf.complex, double: @cbuf.double)
+
+          # Return an empty NArray if asked to read nothing, even if the buffer is empty
+          return @buf.class[] if count == 0
+
+          @cbuf.direct_read(pos: @read_pos, count: count, target: @buf).tap { |v|
             @read_pos = (@read_pos + count) % @cbuf.buffer_size
+            @length -= v.length
           }
+        end
+
+        # For internal use by CircularBuffer.  Increments this reader's internal length value.
+        def wrote(count)
+          raise "BUG: wrote past read position on reader #{@index}" if (count + @length) >
+          @length += count
+        end
+
+        # Returns true if there are no samples available for this reader to read.
+        def empty?
+          @length == 0
         end
       end
 
       # Maximum buffer size
       attr_reader :buffer_size
-
-      # Number of values available for reading
-      attr_reader :length
-      alias count length
 
       # Whether the buffer is real (false) or complex (true)
       attr_reader :bufcomplex
@@ -65,53 +109,64 @@ module MB
 
         @buffer_size = buffer_size
 
-        @read_pos = 0
         @write_pos = 0
-        @length = 0
 
+        # In multi-reader mode, we store all readers in @readers.  In
+        # single-reader mode, we store one reader in @r0.
         @readers = []
+        @r0 = nil
 
-        setup_buffer(length: @buffer_size, complex: complex, temp: true, double: double)
+        setup_buffer(length: @buffer_size, complex: complex, temp: false, double: double)
       end
 
-      # XXX multi-reader idea/experiment
+      # Creates and returns a new Reader for this buffer in multi-reader mode,
+      # with its own independent read pointer.  The read position defaults to
+      # the current write position at time of reader creation (e.g. an empty
+      # buffer), minus the delay specified by +delay_samples+.
+      #
+      # Call this before calling any other methods, as most other methods will
+      # switch the buffer into single-reader mode.
+      #
+      # Raises ReaderModeError if the buffer is in single-reader mode (e.g.
+      # #read, #write, or another method has been called first).
+      #
+      # Raises ArgumentError if +delay_samples+ would put the read pointer
+      # behind the write pointer.
       def reader(delay_samples = 0)
-        # FIXME: include read pos in exception check or something
-        raise 'Cannot delay more than the buffer size' if delay_samples > @buffer_size
+        raise ReaderModeError, 'Buffer is in single-reader mode.  You must call #reader before calling any other methods.' unless @r0.nil?
 
-        Reader.new(cbuf: self, index: @readers.length, read_pos: (@read_pos - delay_samples) % @buffer_size).tap { |r|
+        raise ArgumentError, 'Cannot delay more than the buffer size' if delay_samples > @buffer_size
+
+        Reader.new(
+          cbuf: self,
+          index: @readers.count,
+          read_pos: (@write_pos - delay_samples) % @buffer_size,
+          length: delay_samples
+        ).tap { |r|
           @readers << r
         }
       end
 
-      # Returns the next +count+ samples of the buffer.
+      # Returns the next +count+ samples of the buffer when in single-reader
+      # mode.
+      #
+      # Raises ReaderModeError if the buffer is in multi-reader mode (e.g. if
+      # #reader has been called).
       #
       # Raises BufferUnderflow if +count+ is greater than #length.
       def read(count)
-        # TODO: XXX Just have an internal reader by default and call that?
-
-        # TODO: should we allow short reads (return less than requested)?
-        if count > @length
-          raise BufferUnderflow, "Read of size #{count} is greater than #{@length} available samples"
-        end
-
-        # Return an empty NArray if asked to read nothing, even if the buffer is empty
-        return @buf.class[] if count == 0
-
-        MB::M.circular_read(@buf, @read_pos, count, target: @tmpbuf)[0...count].tap {
-          @read_pos = (@read_pos + count) % @buffer_size
-          @length -= count
-        }
+        default_reader.read(count)
       end
 
       # For internal use by Reader.  Does a direct circular read from the
-      # internal buffer at the given position.
+      # internal buffer at the given position, storing the result in +:target+,
+      # and windowing the target to the given +:count+.
       def direct_read(pos:, count:, target:)
-        MB::M.circular_read(@buf, pos, count, target: target)
+        MB::M.circular_read(@buf, pos, count, target: target)[0...count].not_inplace!
       end
 
-      # Appends the given +narray+ to the circular buffer, returning the
-      # new count of available samples to read.
+      # Appends the given +narray+ to the circular buffer, returning the new
+      # count of available samples to read from the furthest-behind reader.
       #
       # Raises BufferOverflow without writing any data if there's not enough
       # room for the given +narray+ in the buffer.
@@ -129,24 +184,51 @@ module MB
           raise BufferOverflow, "Write of size #{narray.length} is greater than #{available} space available"
         end
 
-        # TODO: XXX take readers buffers into account
         expand_buffer(narray, grow: false)
 
         MB::M.circular_write(@buf, narray, @write_pos)
         @write_pos = (@write_pos + narray.length) % @buffer_size
-        @length += narray.length
+
+        @readers&.each do |r|
+          r.wrote(narray.length)
+        end
+
+        @r0&.wrote(narray.length)
+
+        @readers&.map(&:length)&.max || length
       end
 
-      # Returns the available space left in the circular buffer.  See also
-      # #length.
+      # Returns the number of samples available for reading in single-reader
+      # mode.  Switches to single-reader mode if no mode has been set.
+      #
+      # Raises ReaderModeError if the buffer is in multi-reader mode.
+      def length
+        default_reader.length
+      end
+      alias count length
+
+      # Returns the available space left for writing in the circular buffer,
+      # whether in single-reader or multi-reader mode.  Switches to
+      # single-reader mode if no mode has been set.  See also #length.
       def available
-        # TODO: XXX take readers into account
-        @buffer_size - @length
+        @buffer_size - (@readers.max_by { |v| v.length }&.length || default_reader.length)
       end
 
-      # Returns true if there are no samples in the circular buffer.
+      # Returns true if there are no samples in the circular buffer in any
+      # readers, whether in single-reader (#read) or multi-reader (#reader)
+      # mode.
       def empty?
-        @length == 0
+        @readers.empty? ? default_reader.empty? : @readers.all?(&:empty?)
+      end
+
+      private
+
+      # Returns the default reader if it exists, or switches to single-reader
+      # mode by creating the default reader.  Raises an error if we're already
+      # in multi-reader mode.
+      def default_reader
+        raise ReaderModeError, 'Reader is in multi-reader mode.  Do not call #read or #length after creating a reader with #reader.' unless @readers.empty?
+        @r0 ||= Reader.new(cbuf: self, index: -1, read_pos: 0, length: @write_pos)
       end
     end
   end

--- a/lib/mb/sound/circular_buffer.rb
+++ b/lib/mb/sound/circular_buffer.rb
@@ -92,6 +92,11 @@ module MB
       def available
         @buffer_size - @length
       end
+
+      # Returns true if there are no samples in the circular buffer.
+      def empty?
+        @length == 0
+      end
     end
   end
 end

--- a/lib/mb/sound/filter/delay.rb
+++ b/lib/mb/sound/filter/delay.rb
@@ -6,6 +6,9 @@ module MB
       #
       # See bin/flanger.rb and bin/tape_delay.rb for examples.
       class Delay < Filter
+        # The default delay-time smoothing rate in seconds per second.
+        DEFAULT_SMOOTHING_RATE = 0.5
+
         attr_reader :delay, :delay_samples, :rate, :smoothing, :smooth_limit
         attr_reader :write_offset, :read_offset
 
@@ -15,10 +18,13 @@ module MB
 
         # Initializes a single-channel delay with a given +:delay+ in seconds,
         # based on the sample +:rate+..  The +:buffer_size+ sets the maximum
-        # possible delay.  If +:smoothing+ is true, then the delay time will be
+        # possible delay.
+        #
+        # If +:smoothing+ is true (the default), then the delay time will be
         # adjusted slowly to prevent sudden jumps or clicks in the output.  If
         # +:smoothing+ is a numeric value, then that is the maximum delay
-        # change in seconds allowed per second.
+        # change in seconds allowed per second.  The default smoothing rate is
+        # MB::Sound::Filter::Delay::DEFAULT_SMOOTHING_RATE.
         def initialize(delay: 0, rate: 48000, buffer_size: 48000, smoothing: true)
           if delay.is_a?(Numeric)
             buffer_size = 1.1 * delay * rate if buffer_size < 1.1 * delay * rate
@@ -83,7 +89,7 @@ module MB
             @filter = smoothing
             @smooth_limit = nil
           else
-            new_limit = @rate * (smoothing.is_a?(Numeric) ? smoothing : 0.5)
+            new_limit = @rate * (smoothing.is_a?(Numeric) ? smoothing : DEFAULT_SMOOTHING_RATE)
             if new_limit != @smooth_limit
               @smooth_limit = new_limit
               @filter = MB::Sound::Filter::LinearFollower.new(

--- a/lib/mb/sound/graph_node.rb
+++ b/lib/mb/sound/graph_node.rb
@@ -458,7 +458,7 @@ module MB
       end
 
       # Returns a list of all nodes feeding into this node, either directly or
-      # indirectly.
+      # indirectly, plus this node itself.
       def graph
         source_history = Set.new
         source_queue = [self]
@@ -481,8 +481,7 @@ module MB
       # If there is no graph node with a buffer_size method, then this method
       # returns nil.
       #
-      # TODO: A buffer adapter might be useful.  The MB::Sound::Filter::Delay
-      # class is already kind of like one.
+      # TODO: what should this return when the graph contains a buffer adapter?
       def graph_buffer_size
         size = nil
 
@@ -494,6 +493,16 @@ module MB
         end
 
         size
+      end
+
+      # Appends a BufferAdapter to the graph with this node as its upstream
+      # source, using the given +length+ as the upstream frame size.  When
+      # downstream nodes sample the adapter, the adapter will sample the
+      # upstream node in +length+-sized chunks.  This allows running a node
+      # graph with a shorter internal buffer size than the sound card input or
+      # output buffer size, for example.
+      def with_buffer(length)
+        MB::Sound::GraphNode::BufferAdapter.new(upstream: self, upstream_count: length)
       end
 
       # Looks for the first source node within the graph feeding into this node
@@ -579,3 +588,4 @@ require_relative 'graph_node/proc_node'
 require_relative 'graph_node/tee'
 require_relative 'graph_node/multitap_delay'
 require_relative 'graph_node/complex_node'
+require_relative 'graph_node/buffer_adapter'

--- a/lib/mb/sound/graph_node.rb
+++ b/lib/mb/sound/graph_node.rb
@@ -53,6 +53,7 @@ module MB
 
       # Returns the class name of the node plus the node's assigned name.
       def to_s
+        @graph_node_name ||= nil
         "#{self.class.name}/#{@graph_node_name || __id__}"
       end
 

--- a/lib/mb/sound/graph_node/buffer_adapter.rb
+++ b/lib/mb/sound/graph_node/buffer_adapter.rb
@@ -27,7 +27,7 @@ module MB
 
         # Returns the upstream as the only source for this node.
         def sources
-          [upstream]
+          [@upstream]
         end
 
         # Returns +count+ samples, using as many or as few reads from the

--- a/lib/mb/sound/graph_node/buffer_adapter.rb
+++ b/lib/mb/sound/graph_node/buffer_adapter.rb
@@ -33,18 +33,13 @@ module MB
         # Returns +count+ samples, using as many or as few reads from the
         # upstream as needed to fulfill the request.
         def sample(count)
-          puts "\e[1;35mReading #{count} on #{self} with upstream #{@upstream} and current length of #{@circbuf&.length || 0}\e[0m" # XXX
-
           setup_circular_buffer(count)
 
           while @circbuf.length < count
-            puts "\e[1;36m  Have #{@circbuf.length} out of #{count}.  Asking upstream #{@upstream} for #{@upstream_count}.\e[0m" # XXX
             v = @upstream.sample(@upstream_count)
             @complex ||= v.is_a?(Numo::SComplex) || v.is_a?(Numo::DComplex)
             @circbuf.write(v)
           end
-
-          puts "\e[1;32m  Now have #{@circbuf.length}, returning #{count}.\e[0m" # XXX
 
           @circbuf.read(count).not_inplace!
         end

--- a/lib/mb/sound/graph_node/buffer_adapter.rb
+++ b/lib/mb/sound/graph_node/buffer_adapter.rb
@@ -1,0 +1,64 @@
+module MB
+  module Sound
+    module GraphNode
+      # A graph node that samples its upstream graph using a different sample
+      # count from whatever is passed to this node's #sample method.
+      #
+      # This works by calling the upstream GraphNode#sample method as many
+      # times as necessary to fill the request passed to #sample here if the
+      # upstream buffer size is smaller, and by treating the buffer as a
+      # circular buffer if the upstream buffer size is larger.
+      class BufferAdapter
+        include GraphNode
+
+        attr_reader :upstream_count
+
+        # Creates a buffer adapter with the given +:upstream+ node to sample,
+        # using the given +:upstream_count+ as the value passed to the upstream
+        # sample method.
+        def initialize(upstream:, upstream_count:)
+          raise 'Upstream must respond to :sample' unless upstream.respond_to?(:sample)
+          raise 'Upstream count must be a positive Integer' unless upstream_count.is_a?(Integer) && upstream_count > 0
+
+          @upstream = upstream
+          @upstream_count = upstream_count
+          @complex = false
+        end
+
+        # Returns the upstream as the only source for this node.
+        def sources
+          [upstream]
+        end
+
+        # Returns +count+ samples, using as many or as few reads from the
+        # upstream as needed to fulfill the request.
+        def sample(count)
+          setup_circular_buffer(count)
+
+          while @circbuf.length < count
+            v = @upstream.sample(@upstream_count)
+            @complex ||= v.is_a?(Numo::SComplex) || v.is_a?(Numo::DComplex)
+            @circbuf.write(v)
+          end
+
+          @circbuf.read(count)
+        end
+
+        private
+
+        def setup_circular_buffer(count)
+          # Give us a buffer that can handle a multiple of the upstream count
+          # that is strictly greater than the read count.
+          @bufsize = ((2 * @upstream_count + count) / @upstream_count) * @upstream_count
+          @circbuf ||= CircularBuffer.new(buffer_size: @bufsize, complex: @complex)
+
+          # TODO: resize buffer if needed
+          # TODO: convert to complex if needed
+          if @circbuf.buffer_size != @bufsize || @circbuf.complex != @complex
+            raise NotImplementedError, 'TODO: allow resizing the buffer or switching data types'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mb/sound/graph_node/buffer_adapter.rb
+++ b/lib/mb/sound/graph_node/buffer_adapter.rb
@@ -37,7 +37,15 @@ module MB
 
           while @circbuf.length < count
             v = @upstream.sample(@upstream_count)
+
+            # End of input; return whatever we can from the buffer, or nil
+            if v.nil? || v.empty?
+              return nil if @circbuf.length == 0
+              return @circbuf.read(MB::M.min(count, @circbuf.length))
+            end
+
             @complex ||= v.is_a?(Numo::SComplex) || v.is_a?(Numo::DComplex)
+
             @circbuf.write(v)
           end
 

--- a/lib/mb/sound/graph_node/buffer_adapter.rb
+++ b/lib/mb/sound/graph_node/buffer_adapter.rb
@@ -33,15 +33,20 @@ module MB
         # Returns +count+ samples, using as many or as few reads from the
         # upstream as needed to fulfill the request.
         def sample(count)
+          puts "\e[1;35mReading #{count} on #{self} with upstream #{@upstream} and current length of #{@circbuf&.length || 0}\e[0m" # XXX
+
           setup_circular_buffer(count)
 
           while @circbuf.length < count
+            puts "\e[1;36m  Have #{@circbuf.length} out of #{count}.  Asking upstream #{@upstream} for #{@upstream_count}.\e[0m" # XXX
             v = @upstream.sample(@upstream_count)
             @complex ||= v.is_a?(Numo::SComplex) || v.is_a?(Numo::DComplex)
             @circbuf.write(v)
           end
 
-          @circbuf.read(count)
+          puts "\e[1;32m  Now have #{@circbuf.length}, returning #{count}.\e[0m" # XXX
+
+          @circbuf.read(count).not_inplace!
         end
 
         private

--- a/lib/mb/sound/graph_node/complex_node.rb
+++ b/lib/mb/sound/graph_node/complex_node.rb
@@ -23,7 +23,7 @@ module MB
         # Returns a source list containing the original input given to the
         # constructor.
         def sources
-          [@inout]
+          [@input]
         end
 
         # Converts the next +count+ samples from the original input according

--- a/lib/mb/sound/graph_node/constant.rb
+++ b/lib/mb/sound/graph_node/constant.rb
@@ -5,6 +5,7 @@ module MB
       # that returns a constant numeric value.
       class Constant
         include GraphNode
+        include BufferHelper
 
         module NumericConstantMethods
           # Converts this numeric value into a MB::Sound::GraphNode::Constant
@@ -37,6 +38,7 @@ module MB
         def initialize(constant, smoothing: nil)
           raise 'The constant value must be a numeric' unless constant.is_a?(Numeric)
           @constant = constant
+          @complex = @constant.is_a?(Complex)
           @old_constant = constant
           @smoothing = smoothing
           @buf = nil
@@ -44,7 +46,9 @@ module MB
 
         # Returns +count+ samples of the constant value.
         def sample(count)
-          setup_buffer(count)
+          @complex ||= @constant.is_a?(Complex)
+
+          setup_buffer(length: count, complex: @complex)
 
           smoothing = @smoothing || @smoothing.nil?
           if @constant != @old_constant && smoothing
@@ -63,17 +67,6 @@ module MB
 
         def sources
           [@constant]
-        end
-
-        private
-
-        def setup_buffer(length)
-          @complex = @constant.is_a?(Complex)
-          @bufclass = @complex ? Numo::SComplex : Numo::SFloat
-
-          if @buf.nil? || @buf.length != length || @bufclass != @buf.class
-            @buf = @bufclass.zeros(length)
-          end
         end
       end
     end

--- a/lib/mb/sound/graph_node/input_channel_split.rb
+++ b/lib/mb/sound/graph_node/input_channel_split.rb
@@ -14,14 +14,18 @@ module MB
       #
       # See also the Tee class, which is very similar.
       class InputChannelSplit
+        # Raised when any channel's internal buffer overflows.  This would
+        # happen if the downstream buffer size is significantly larger than the
+        # input's buffer size, or if one channel is being read more than
+        # another.
+        class ChannelBufferOverflow < MB::Sound::CircularBuffer::BufferOverflow; end
+
         # An individual channel of an input channel splitter, returned by
         # InputChannelSplit#channels.
         #
         # TODO: Maybe this can be deduplicated with Tee.
         class InputChannelNode
           include GraphNode
-
-          attr_reader :need_sample
 
           # For internal use by InputChannelSplit.  Initializes one output
           # channel of the split.
@@ -31,9 +35,11 @@ module MB
             @graph_node_name = name
           end
 
-          # Retrieves the next buffer for this channel.  The InputChannelSplit
-          # will print a warning if any channel is sampled more than once without
-          # all channels being sampled once.
+          # Retrieves the next +count+ samples for this channel.
+          #
+          # This method may modify and return the same object multiple times,
+          # so duplicate the returned buffer if you need to retain multiple
+          # past buffers.
           def sample(count)
             @split.internal_sample(self, @channel, count)
           end
@@ -68,11 +74,12 @@ module MB
             InputChannelNode.new(self, idx, "#{source.graph_node_name}: Channel #{idx}")
           }.freeze
 
-          # List of channels that have already read the current buffer, to detect
-          # when a new buffer is needed.
-          @read_channels = Set.new
+          bufsize = MB::M.max(source.buffer_size * 3, 48000)
+          @cbufs = Array.new(max_channels) {
+            CircularBuffer.new(buffer_size: bufsize)
+          }
 
-          @buf = nil
+          @done = false
         end
 
         # For internal use by InputChannelNode#sample.  Returns the current
@@ -84,32 +91,37 @@ module MB
         # channels) is read from the source node.
         def internal_sample(node, channel, count)
           # TODO: maybe dedupe with Tee?
-          if @read_channels.include?(node)
-            if @read_channels.length != @channels.length
-              warn "Channel #{channel} on InputChannelSplit #{self} sampled again with #{@read_channels.length} of #{@channels.length} sampled"
-            end
 
-            @read_channels.clear
-            @buf = nil
+          while !@done && @cbufs[channel].length < count
+            read_once
           end
 
-          if @buf && @buf[0].length != count
-            @buf = @buf.map { |b|
-              if b
-                if !b.empty?
-                  MB::M.zpad(b, count)
-                else
-                  nil
-                end
+          return nil if @done && @cbufs[idx].empty?
+
+          @cbufs[channel].read(MB::M.min(@cbufs[channel].length, count)).not_inplace!
+        end
+
+        private
+
+        # Reads one buffer from the upstream input and stores each channel in a
+        # separate circular buffer.  This allows temporary desyncing between
+        # channels, which may happen if the input buffer size is e.g. 800 but
+        # the node graph is running with a buffer size of 1024.
+        def read_once
+          buf = @source.read(@source.buffer_size)
+
+          if buf.nil? || buf.empty? || buf.any?(&:empty?)
+            @done = true
+          else
+            @cbufs.each_with_index do |c, idx|
+              begin
+                c.write(buf[idx])
+              rescue MB::Sound::CircularBuffer::BufferOverflow => e
+                raise ChannelBufferOverflow, "Channel #{idx + 1} of #{@channels.count} buffer is full; " \
+                  "is one channel being sampled more than others?  Buffers: #{@cbufs.map(&:length)}"
               end
-            }
+            end
           end
-
-          @read_channels << node
-
-          @buf ||= @source.read(count)
-
-          @buf[channel]
         end
       end
     end

--- a/lib/mb/sound/graph_node/input_channel_split.rb
+++ b/lib/mb/sound/graph_node/input_channel_split.rb
@@ -96,7 +96,7 @@ module MB
             read_once
           end
 
-          return nil if @done && @cbufs[idx].empty?
+          return nil if @done && @cbufs[channel].empty?
 
           @cbufs[channel].read(MB::M.min(@cbufs[channel].length, count)).not_inplace!
         end

--- a/lib/mb/sound/graph_node/multitap_delay.rb
+++ b/lib/mb/sound/graph_node/multitap_delay.rb
@@ -190,6 +190,8 @@ module MB
 
         # TODO: There's got to be a way to abstract this common buffer
         # management that occurs in a lot of different classes
+        # 
+        # TODO: maybe use BufferHelper
         def update_buf(type, min_length)
           length = min_length
           length = @buf.length if @buf.length > min_length

--- a/lib/mb/sound/graph_node/node_sequence.rb
+++ b/lib/mb/sound/graph_node/node_sequence.rb
@@ -2,16 +2,66 @@ module MB
   module Sound
     module GraphNode
       # A signal graph node that switches from input node to input node as each
-      # input node runs out of data.
+      # input node runs out of data.  See GraphNode#and_then.
+      #
+      # Note that some input sources, such as IO objects and Tones, will pad
+      # their outputs to fill an entire buffer size, so the sequence may be a
+      # handful of samples longer than expected.
       class NodeSequence
         include GraphNode
 
         # See GraphNode#sources.
         attr_reader :sources
 
-        # Creates a node sequence with the given sources to play in order.
-        def initialize(sources)
-          @sources = Array(sources).map { |s|
+        # Creates a node sequence with the given sources (either Numo::NArrays
+        # or a GraphNodes) to play in order.
+        def initialize(*sources)
+          @sources = nil
+          @current_sources = nil
+          @circbuf = MB::Sound::CircularBuffer.new(buffer_size: 48000, complex: false, double: false)
+
+          and_then(*sources)
+        end
+
+        # Retrieves the next +count+ samples of audio from the current source, or
+        # returns nil if all sources have run out of data.  Sources are
+        # stitched together gaplessly unless the source itself zero-pads its
+        # output.  If the final source returns too few samples to reach
+        # +count+, then the buffer will be zero-padded to +count+ samples.
+        def sample(count)
+          return nil if @circbuf.empty? && @current_sources.empty?
+
+          while @circbuf.length < count && @current_sources.any?
+            buf = @current_sources[0].sample(count)
+
+            if buf.nil? || buf.empty?
+              @current_sources.shift
+            else
+              @circbuf.write(buf)
+            end
+          end
+
+          if @circbuf.length == 0
+            nil
+          elsif @circbuf.length < count
+            MB::M.zpad(@circbuf.read(@circbuf.length), count)
+          else
+            @circbuf.read(MB::M.min(count, @circbuf.length))
+          end
+        end
+
+        # Adds the given sources (wrapping Numo::NArray with ArrayInput) to the
+        # sequence.  This method allows chaining GraphNode#and_then in the
+        # GraphNode DSL without building more NodeSequence objects.
+        def and_then(*sources)
+          sources = sources[0] if sources.length == 1 && sources[0].is_a?(Array)
+
+          # FIXME: ArrayInput (thorugh IOSampleMixin) and Tone always return a
+          # full buffer even if they've exceeded their duration.  It would
+          # probably be better to move zero-padding as far toward the end of a
+          # signal chain as possible, ideally at the point of generating
+          # output.
+          source_list = Array(sources).map { |s|
             if s.is_a?(Numo::NArray)
               ArrayInput.new(data: [s])
             else
@@ -19,29 +69,15 @@ module MB
             end
           }.freeze
 
-          @current_sources = @sources.dup
-        end
-
-        # Retrieves the next +count+ samples of audio from the current source, or
-        # returns nil if all sources have run out of data.  If a source returns
-        # fewer than +count+ samples, then the buffer will be zero-padded to
-        # +count+ samples.
-        #
-        # FIXME: only zero pad the last source, otherwise concatenate sources
-        def sample(count)
-          buf = nil
-
-          while (buf.nil? || buf.empty?) && !@current_sources.empty?
-            buf = @current_sources[0].sample(count)
-
-            if buf.nil? || buf.empty?
-              @current_sources.shift
-            elsif buf.length < count
-              buf = MB::M.zpad(buf, count)
-            end
+          if @sources
+            @sources = (@sources + source_list).freeze
+            @current_sources += source_list
+          else
+            @sources = source_list
+            @current_sources = @sources.dup
           end
 
-          buf
+          self
         end
       end
     end

--- a/lib/mb/sound/graph_node/node_sequence.rb
+++ b/lib/mb/sound/graph_node/node_sequence.rb
@@ -26,6 +26,8 @@ module MB
         # returns nil if all sources have run out of data.  If a source returns
         # fewer than +count+ samples, then the buffer will be zero-padded to
         # +count+ samples.
+        #
+        # FIXME: only zero pad the last source, otherwise concatenate sources
         def sample(count)
           buf = nil
 

--- a/lib/mb/sound/graph_node/tee.rb
+++ b/lib/mb/sound/graph_node/tee.rb
@@ -106,7 +106,7 @@ module MB
             if @buf.length == 0
               return nil
             elsif @buf.length != count
-              raise "Branch #{branch} on Tee #{self} requested #{count} samples when the buffer has #{@buf.length}"
+              raise "Branch #{branch} on Tee #{self} of #{@source} requested #{count} samples when the buffer has #{@buf.length}"
             end
           end
 

--- a/lib/mb/sound/graph_node/tee.rb
+++ b/lib/mb/sound/graph_node/tee.rb
@@ -93,7 +93,7 @@ module MB
           # TODO: maybe dedupe with InputChannelSplit?
           if @read_branches.include?(branch)
             if @read_branches.length != @branches.length
-              warn "Branch #{branch}/#{branch.graph_node_name} on Tee #{self} sampled again with #{@read_branches.length} of #{@branches.length} sampled"
+              warn "Branch #{branch}/#{branch.graph_node_name} on Tee #{self} of #{@source} sampled again with #{@read_branches.length} of #{@branches.length} sampled"
             end
 
             @read_branches.clear

--- a/lib/mb/sound/io_methods.rb
+++ b/lib/mb/sound/io_methods.rb
@@ -215,7 +215,9 @@ module MB
       end
 
       # Tries to auto-detect an input device for recording sound.  Returns a
-      # sound input stream with a :read method.
+      # sound input stream with a :read method for reading all channels, and
+      # :split and :sample methods for use with node graphs (see GraphNode and
+      # GraphNode::IOSampleMixin).
       #
       # For input types that support naming a specific device, the INPUT_DEVICE
       # environment variable, the DEVICE environment variable, or the +:device+
@@ -253,6 +255,10 @@ module MB
           raise NotImplementedError, 'TODO: support other platforms'
         end
 
+        # mb-sound-jackffi cannot depend on this gem since we depend on it.
+        # Therefore we have to mix in GraphNode stuff here instead of including
+        # it in mb-sound-jackffi.  We could split the node graph code into a
+        # separate gem to get around this.
         inp.extend(GraphNode) unless inp.is_a?(GraphNode)
         inp.extend(GraphNode::IOSampleMixin) unless inp.is_a?(GraphNode::IOSampleMixin)
 

--- a/lib/mb/sound/null_input.rb
+++ b/lib/mb/sound/null_input.rb
@@ -6,6 +6,9 @@ module MB
     # Note: the buffer will be reused unless it has to be resized, so do not make
     # any modifications to the buffer.
     class NullInput
+      include GraphNode
+      include GraphNode::IOSampleMixin
+
       attr_reader :channels, :length, :remaining, :samples_read, :rate, :buffer_size
 
       # Initializes a null audio stream that returns the +fill+ value +length+

--- a/lib/mb/sound/version.rb
+++ b/lib/mb/sound/version.rb
@@ -1,5 +1,5 @@
 module MB
   module Sound
-    VERSION = "0.7.1.usegit"
+    VERSION = "0.8.0.usegit"
   end
 end

--- a/mb-sound.gemspec
+++ b/mb-sound.gemspec
@@ -30,15 +30,18 @@ Gem::Specification.new do |spec|
   spec.extensions = ['ext/mb/fast_sound/extconf.rb']
 
   spec.add_runtime_dependency 'cmath', '~> 1.0.0'
-  spec.add_runtime_dependency 'numo-narray', '~> 0.9.1.8'
+  spec.add_runtime_dependency 'numo-narray', '~> 0.9.2'
   spec.add_runtime_dependency 'numo-pocketfft', '~> 0.4.1'
 
   spec.add_runtime_dependency 'midi-nibbler', '~> 0.2.4'
 
   spec.add_runtime_dependency 'midilib', '~> 4.0.0'
 
-  spec.add_runtime_dependency 'mb-math', '>= 0.2.1.usegit'
+  spec.add_runtime_dependency 'mb-math', '>= 0.2.2.usegit'
   spec.add_runtime_dependency 'mb-util', '>= 0.1.21.usegit'
+
+  spec.add_development_dependency 'rake', '~> 13.0.1'
+  spec.add_development_dependency 'bundler', '2.4.22'
 
   # For generating MIDI controller templates for ACID
   spec.add_development_dependency 'builder', '~> 3.2.4'

--- a/spec/lib/mb/sound/buffer_helper_spec.rb
+++ b/spec/lib/mb/sound/buffer_helper_spec.rb
@@ -1,0 +1,147 @@
+RSpec.describe(MB::Sound::BufferHelper, :aggregate_failures) do
+  let(:bufhelper) {
+    c = Class.new do
+      include MB::Sound::BufferHelper
+
+      attr_reader :buf, :tmpbuf
+
+      def setup_buffer(**a)
+        super
+      end
+
+      def grow_buffer(**a)
+        super
+      end
+    end
+
+    c.new
+  }
+
+  describe '#setup_buffer' do
+    shared_examples_for(:setup_buffer) do
+      it 'can create a real float buffer' do
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
+        expect(buf).to be_a(Numo::SFloat)
+        expect(buf.length).to eq(5)
+      end
+
+      it 'can create a real double buffer' do
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: true)
+        expect(buf).to be_a(Numo::DFloat)
+        expect(buf.length).to eq(5)
+      end
+
+      it 'can create a complex float buffer' do
+        bufhelper.setup_buffer(length: 5, complex: true, temp: temp, double: false)
+        expect(buf).to be_a(Numo::SComplex)
+        expect(buf.length).to eq(5)
+      end
+
+      it 'can create a complex double buffer' do
+        bufhelper.setup_buffer(length: 5, complex: true, temp: temp, double: true)
+        expect(buf).to be_a(Numo::DComplex)
+        expect(buf.length).to eq(5)
+      end
+
+      it 'preserves contents when promoting a float buffer to double' do
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
+        expect(buf).to be_a(Numo::SFloat)
+
+        buf[] = Numo::SFloat[1, 2, 3, 4, 5]
+
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: true)
+        expect(buf).to be_a(Numo::DFloat).and eq(Numo::DFloat[1, 2, 3, 4, 5])
+      end
+
+      it 'preserves contents when promoting float real to complex' do
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
+        expect(buf).to be_a(Numo::SFloat)
+
+        buf[] = Numo::SFloat[1, 2, 3, 4, 5]
+
+        bufhelper.setup_buffer(length: 5, complex: true, temp: temp, double: false)
+        expect(buf).to be_a(Numo::SComplex).and eq(Numo::SComplex[1, 2, 3, 4, 5])
+      end
+
+      it 'preserves contents when promoting float real to complex double' do
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
+        expect(buf).to be_a(Numo::SFloat)
+
+        buf[] = Numo::SFloat[1, 2, 3, 4, 5]
+
+        bufhelper.setup_buffer(length: 5, complex: true, temp: temp, double: true)
+        expect(buf).to be_a(Numo::DComplex).and eq(Numo::DComplex[1, 2, 3, 4, 5])
+      end
+
+      it 'preserves contents when growing a buffer' do
+        bufhelper.setup_buffer(length: 3, complex: false, temp: temp, double: false)
+        buf[] = Numo::SFloat[1, -1, 2]
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
+        expect(buf).to eq(Numo::SFloat[1, -1, 2, 0, 0])
+      end
+
+      it 'preserves contents when shrinking a buffer, as much as possible' do
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
+        buf[] = Numo::SFloat[1, 2, 3, 4, 5]
+        bufhelper.setup_buffer(length: 2, complex: false, temp: temp, double: false)
+        expect(buf).to eq(Numo::SFloat[1, 2])
+      end
+
+      it 'can both grow and convert a buffer within a single call, preserving contents' do
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
+        buf[] = Numo::SFloat[1,2,3,4,5]
+
+        bufhelper.setup_buffer(length: 6, complex: true, temp: temp, double: false)
+        expect(buf).to be_a(Numo::SComplex).and eq(Numo::SComplex[1,2,3,4,5,0])
+      end
+
+      it 'can both shrink and convert a buffer within a single call, preserving contents' do
+        bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
+        buf[] = Numo::SFloat[1,2,3,4,5]
+
+        bufhelper.setup_buffer(length: 3, complex: true, temp: temp, double: false)
+        expect(buf).to be_a(Numo::SComplex).and eq(Numo::SComplex[1,2,3])
+      end
+    end
+
+    context 'when temp is false' do
+      let(:temp) { false }
+
+      context 'working with @buf' do
+        def buf; bufhelper.buf; end
+        it_behaves_like :setup_buffer
+      end
+
+      it 'does not create a temporary buffer' do
+        bufhelper.setup_buffer(length: 3, complex: false, temp: false, double: false)
+        expect(bufhelper.tmpbuf).to eq(nil)
+      end
+    end
+
+    context 'when temp is true' do
+      let(:temp) { true }
+
+      context 'working with @buf' do
+        def buf; bufhelper.buf; end
+        it_behaves_like :setup_buffer
+      end
+
+      context 'working with @tmpbuf' do
+        def buf; bufhelper.tmpbuf; end
+        it_behaves_like :setup_buffer
+      end
+
+      it 'creates a temporary buffer' do
+        bufhelper.setup_buffer(length: 3, complex: false, temp: true, double: false)
+        expect(bufhelper.tmpbuf).to be_a(Numo::SFloat)
+      end
+    end
+
+    it 'raises an error when trying to convert from complex to real' do
+      bufhelper.setup_buffer(length: 5, complex: true, temp: false, double: false)
+      expect {
+        bufhelper.setup_buffer(length: 5, complex: false, temp: false, double: false)
+      }.to raise_error(Numo::NArray::CastError)
+    end
+  end
+end

--- a/spec/lib/mb/sound/buffer_helper_spec.rb
+++ b/spec/lib/mb/sound/buffer_helper_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe(MB::Sound::BufferHelper, :aggregate_failures) do
 
       attr_reader :buf, :tmpbuf
 
-      def setup_buffer(**a)
+      def setup_buffer(*a, **ka)
         super
       end
 
-      def grow_buffer(**a)
+      def expand_buffer(*a, **ka)
         super
       end
     end
@@ -18,7 +18,7 @@ RSpec.describe(MB::Sound::BufferHelper, :aggregate_failures) do
   }
 
   describe '#setup_buffer' do
-    shared_examples_for(:setup_buffer) do
+    shared_examples_for :setup_buffer do
       it 'can create a real float buffer' do
         bufhelper.setup_buffer(length: 5, complex: false, temp: temp, double: false)
         expect(buf).to be_a(Numo::SFloat)
@@ -104,7 +104,7 @@ RSpec.describe(MB::Sound::BufferHelper, :aggregate_failures) do
       end
     end
 
-    context 'when temp is false' do
+    context 'when :temp is false' do
       let(:temp) { false }
 
       context 'working with @buf' do
@@ -118,7 +118,7 @@ RSpec.describe(MB::Sound::BufferHelper, :aggregate_failures) do
       end
     end
 
-    context 'when temp is true' do
+    context 'when :temp is true' do
       let(:temp) { true }
 
       context 'working with @buf' do
@@ -142,6 +142,92 @@ RSpec.describe(MB::Sound::BufferHelper, :aggregate_failures) do
       expect {
         bufhelper.setup_buffer(length: 5, complex: false, temp: false, double: false)
       }.to raise_error(Numo::NArray::CastError)
+    end
+  end
+
+  describe '#expand_buffer' do
+    before do
+      bufhelper.setup_buffer(length: 6, temp: temp, complex: false, double: false)
+      bufhelper.buf[] = Numo::SFloat[1, 2, 3, 4, 5, -6]
+      bufhelper.tmpbuf[] = bufhelper.buf if temp
+    end
+
+    shared_examples_for :expand_buffer do
+      it 'promotes float to double' do
+        expect(buf).to be_a(Numo::SFloat)
+        bufhelper.expand_buffer(Numo::DFloat[])
+        expect(buf).to be_a(Numo::DFloat).and eq(Numo::DFloat[1,2,3,4,5,-6])
+      end
+
+      it 'promotes real to complex' do
+        expect(buf).to be_a(Numo::SFloat)
+        bufhelper.expand_buffer(Numo::SComplex[])
+        expect(buf).to be_a(Numo::SComplex).and eq(Numo::SComplex[1,2,3,4,5,-6])
+      end
+
+      it 'does not demote double to float' do
+        bufhelper.expand_buffer(Numo::DFloat[])
+        bufhelper.expand_buffer(Numo::SFloat[])
+        expect(buf).to be_a(Numo::DFloat).and eq(Numo::DFloat[1,2,3,4,5,-6])
+      end
+
+      it 'does not demote complex to real' do
+        expect(buf).to be_a(Numo::SFloat)
+        bufhelper.expand_buffer(Numo::DComplex[1,2,3,4,5,6])
+        bufhelper.expand_buffer(Numo::DFloat[1,2,3,4,5,6,7])
+        expect(buf).to be_a(Numo::DComplex).and eq(Numo::DComplex[1,2,3,4,5,-6])
+      end
+
+      it 'does not reduce length' do
+        bufhelper.expand_buffer(Numo::SFloat[1,2])
+        expect(buf.length).to eq(6)
+      end
+
+      it 'does not increase length if grow is false' do
+        bufhelper.expand_buffer(Numo::SFloat[1,2,3,4,5,6,7,8,9], grow: false)
+        expect(buf.length).to eq(6)
+      end
+
+      it 'can change length and type together' do
+        expect(buf).to be_a(Numo::SFloat)
+        bufhelper.expand_buffer(Numo::DComplex[1,2,3,4,5,6,7])
+        expect(buf).to be_a(Numo::DComplex).and eq(Numo::DComplex[1,2,3,4,5,-6,0])
+      end
+    end
+
+    context 'when :temp is false' do
+      let(:temp) { false }
+
+      context 'working with @buf' do
+        def buf; bufhelper.buf; end
+        it_behaves_like :expand_buffer
+      end
+
+      it 'does not create a temporary buffer' do
+        bufhelper.expand_buffer(Numo::DComplex[1,2,3,4,5,6,7,8,9])
+        expect(bufhelper.buf).to be_a(Numo::DComplex)
+        expect(bufhelper.tmpbuf).to eq(nil)
+      end
+    end
+
+    context 'when :temp is true' do
+      let(:temp) { true }
+
+      context 'working with @buf' do
+        def buf; bufhelper.buf; end
+        it_behaves_like :expand_buffer
+      end
+
+      context 'working with @tmpbuf' do
+        def buf; bufhelper.tmpbuf; end
+        it_behaves_like :expand_buffer
+      end
+
+      it 'does not create a temporary buffer' do
+        bufhelper.expand_buffer(Numo::DComplex[1,2,3,4,5,6,7,8,9])
+        expect(bufhelper.buf).to be_a(Numo::DComplex)
+        expect(bufhelper.tmpbuf).to be_a(Numo::DComplex)
+      end
     end
   end
 end

--- a/spec/lib/mb/sound/circular_buffer_spec.rb
+++ b/spec/lib/mb/sound/circular_buffer_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe(MB::Sound::CircularBuffer) do
+  it 'can read and write data' do
+    cbuf = MB::Sound::CircularBuffer.new(buffer_size: 7)
+    expect(cbuf.buffer_size).to eq(7)
+
+    expect(cbuf.write(Numo::SFloat[1, 2, 3])).to eq(3)
+    expect(cbuf.write(Numo::SFloat[4, 5])).to eq(5)
+    expect(cbuf.length).to eq(5)
+    expect(cbuf.available).to eq(2)
+
+    expect(cbuf.read(4)).to eq(Numo::SFloat[1,2,3,4])
+    expect(cbuf.length).to eq(1)
+    expect(cbuf.available).to eq(6)
+    
+    expect(cbuf.write(Numo::SFloat[-1, -2, -3, -4, -5, -6])).to eq(7)
+    expect(cbuf.length).to eq(7)
+    expect(cbuf.available).to eq(0)
+
+    expect(cbuf.read(5)).to eq(Numo::SFloat[5, -1, -2, -3, -4])
+    expect(cbuf.length).to eq(2)
+    expect(cbuf.available).to eq(5)
+
+    expect(cbuf.read(2)).to eq(Numo::SFloat[-5, -6])
+    expect(cbuf.length).to eq(0)
+    expect(cbuf.available).to eq(7)
+
+    expect(cbuf.write(Numo::SFloat[1,2,3,4,5,6,7])).to eq(7)
+    expect(cbuf.length).to eq(7)
+    expect(cbuf.available).to eq(0)
+
+    expect(cbuf.read(7)).to eq(Numo::SFloat[1,2,3,4,5,6,7])
+    expect(cbuf.length).to eq(0)
+    expect(cbuf.available).to eq(7)
+  end
+
+  pending 'with complex values'
+  pending 'with double precision values'
+
+  pending 'raises errors on buffer underflow and overflow'
+  pending 'can be resized'
+  pending 'can be switched from real to complex'
+end

--- a/spec/lib/mb/sound/circular_buffer_spec.rb
+++ b/spec/lib/mb/sound/circular_buffer_spec.rb
@@ -1,6 +1,84 @@
 RSpec.describe(MB::Sound::CircularBuffer, :aggregate_failures) do
   let(:cbuf) { MB::Sound::CircularBuffer.new(buffer_size: 7) }
 
+  describe '::Reader' do
+    describe '#read' do
+      it 'can adapt to changes in data type' do
+        r1 = cbuf.reader
+        r2 = cbuf.reader(1)
+        cbuf.write(Numo::SFloat[1,2,3,4])
+        expect(r1.read(2)).to be_a(Numo::SFloat).and eq(Numo::SFloat[1,2])
+        cbuf.write(Numo::SComplex[-1i])
+
+        expect(r2.read(2)).to be_a(Numo::SComplex).and eq(Numo::SComplex[0, 1])
+        expect(r1.read(3)).to be_a(Numo::SComplex).and eq(Numo::SComplex[3, 4, -1i])
+      end
+
+      it 'raises an error if trying to read more data than is available' do
+        r1 = cbuf.reader
+        cbuf.write(Numo::SFloat[1,2])
+        r2 = cbuf.reader
+        expect { r2.read(1) }.to raise_error(MB::Sound::CircularBuffer::BufferUnderflow)
+        expect { r1.read(3) }.to raise_error(MB::Sound::CircularBuffer::BufferUnderflow)
+        expect(r1.read(1)).to eq(Numo::SFloat[1])
+      end
+
+      it 'returns an empty NArray if asked for zero samples' do
+        r1 = cbuf.reader
+        expect(r1.read(0)).to be_a(Numo::SFloat).and(eq(Numo::SFloat[]))
+
+        cbuf.write(Numo::SComplex[1])
+        expect(r1.read(0)).to be_a(Numo::SComplex).and(eq(Numo::SComplex[]))
+      end
+    end
+
+    describe '#empty?' do
+      it 'returns false if there are samples to read' do
+        r1 = cbuf.reader
+        cbuf.write(Numo::SFloat[1, 2])
+        r2 = cbuf.reader
+        cbuf.write(Numo::SFloat[3])
+        r3 = cbuf.reader(1)
+
+        expect(r1.empty?).to eq(false)
+        expect(r2.empty?).to eq(false)
+        expect(r3.empty?).to eq(false)
+      end
+
+      it 'returns true if there are no samples to read' do
+        r1 = cbuf.reader
+        expect(r1.empty?).to eq(true)
+
+        cbuf.write(Numo::SFloat[1, 2])
+        r2 = cbuf.reader
+        expect(r2.empty?).to eq(true)
+      end
+    end
+
+    describe '#length' do
+      it 'starts at zero if there is no delay' do
+        r1 = cbuf.reader
+        expect(r1.length).to eq(0)
+
+        cbuf.write(Numo::SFloat[1])
+        r2 = cbuf.reader
+        expect(r2.length).to eq(0)
+      end
+
+      it 'increases when the buffer is written' do
+        r1 = cbuf.reader
+        r2 = cbuf.reader(3)
+        expect {
+          cbuf.write(Numo::SFloat[-1, -2])
+        }.to change { r1.length }.by(2).and(change { r2.length }.by(2))
+      end
+
+      it 'starts at the delay if a delay is given' do
+        expect(cbuf.reader(4).length).to eq(4)
+      end
+    end
+  end
+
   it 'maintains length and available values while reading and writing data' do
     expect(cbuf.buffer_size).to eq(7)
 
@@ -94,14 +172,145 @@ RSpec.describe(MB::Sound::CircularBuffer, :aggregate_failures) do
       cbuf.write(Numo::DComplex[-1i])
       expect(cbuf.read(0)).to eq(Numo::DComplex[])
     end
+
+    it 'raises an error if #reader has been called' do
+      cbuf.reader
+      expect { cbuf.read(0) }.to raise_error(MB::Sound::CircularBuffer::ReaderModeError)
+    end
   end
 
   describe '#write' do
-    it 'raises an error if writing more data than will fit in the buffer' do
-      expect { cbuf.write(Numo::SFloat[1,2,3,4,5,6,7,8]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+    context 'in single-reader mode' do
+      it 'raises an error if writing more data than will fit in the buffer' do
+        expect { cbuf.write(Numo::SFloat[1,2,3,4,5,6,7,8]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
 
-      cbuf.write(Numo::DComplex[1,2])
-      expect { cbuf.write(Numo::SFloat[1,2,3,4,5,6]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+        cbuf.write(Numo::DComplex[1,2])
+        expect { cbuf.write(Numo::SFloat[1,2,3,4,5,6]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+      end
+    end
+
+    context 'in multi-reader mode' do
+      it 'can write up to the position of the slowest reader' do
+        r1 = cbuf.reader
+        r2 = cbuf.reader(3)
+
+        expect { cbuf.write(Numo::SFloat[1,2,3,4]) }.not_to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+      end
+
+      it 'raises an error if the write would pass any of the read positions' do
+        r1 = cbuf.reader
+        r2 = cbuf.reader(3)
+
+        expect { cbuf.write(Numo::SFloat[1,2,3,4,5]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+      end
+    end
+  end
+
+  describe '#reader' do
+    it 'can create multiple readers' do
+      r1 = cbuf.reader
+      r2 = cbuf.reader
+      r3 = cbuf.reader
+
+      cbuf.write(Numo::SFloat[1,2,3,4,5,6,7])
+
+      expect(r1.read(7)).to eq(Numo::SFloat[1,2,3,4,5,6,7])
+      expect(r2.read(4)).to eq(Numo::SFloat[1,2,3,4])
+      expect(r3.read(3)).to eq(Numo::SFloat[1,2,3])
+      expect(r2.read(2)).to eq(Numo::SFloat[5,6])
+      expect(r3.read(1)).to eq(Numo::SFloat[4])
+    end
+
+    it 'creates readers at the write pointer' do
+      r1 = cbuf.reader
+      cbuf.write(Numo::SFloat[5,4,3])
+      r2 = cbuf.reader
+      cbuf.write(Numo::SFloat[-1,-2])
+      expect(r1.read(4)).to eq(Numo::SFloat[5,4,3,-1])
+      expect(r2.read(2)).to eq(Numo::SFloat[-1,-2])
+    end
+
+    it 'can create a delayed reader' do
+      r1 = cbuf.reader(5)
+      expect(r1.length).to eq(5)
+      expect(cbuf.available).to eq(2)
+      expect { cbuf.write(Numo::SFloat[1,2,3]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+    end
+
+    it 'raises an error if #write was called before calling #reader' do
+      cbuf.write(Numo::SFloat[1])
+      expect { cbuf.reader }.to raise_error(MB::Sound::CircularBuffer::ReaderModeError)
+    end
+
+    it 'raises an error if #read has been called' do
+      cbuf.read(0)
+      expect { cbuf.reader }.to raise_error(MB::Sound::CircularBuffer::ReaderModeError)
+    end
+
+    it 'raises an error if #length has been called' do
+      cbuf.length
+      expect { cbuf.reader }.to raise_error(MB::Sound::CircularBuffer::ReaderModeError)
+    end
+
+    it 'raises an error if #available was called first' do
+      cbuf.available
+      expect { cbuf.reader }.to raise_error(MB::Sound::CircularBuffer::ReaderModeError)
+    end
+
+    it 'raises an error if #empty? was called first' do
+      cbuf.empty?
+      expect { cbuf.reader }.to raise_error(MB::Sound::CircularBuffer::ReaderModeError)
+    end
+  end
+
+  describe '#length' do
+    context 'in multi-reader mode' do
+      it 'raises an error' do
+        cbuf.reader
+        expect { cbuf.length }.to raise_error(MB::Sound::CircularBuffer::ReaderModeError)
+      end
+    end
+
+    context 'in single-reader mode' do
+      it 'returns samples available for writing' do
+        expect(cbuf.length).to eq(0)
+        cbuf.write(Numo::SFloat[1,2,3])
+        expect(cbuf.length).to eq(3)
+      end
+    end
+  end
+
+  describe '#available' do
+    context 'in multi-reader mode' do
+      it 'returns the samples that can be written without passing the furthest-behind reader' do
+        cbuf.reader
+        expect(cbuf.available).to eq(7)
+        cbuf.reader(2)
+        expect(cbuf.available).to eq(5)
+        cbuf.reader(7)
+        expect(cbuf.available).to eq(0)
+      end
+    end
+
+    context 'in single-reader mode' do
+      it 'returns the number of samples that can be written' do
+        expect(cbuf.available).to eq(7)
+        cbuf.write(Numo::SFloat[1,2,3])
+        expect(cbuf.available).to eq(4)
+      end
+    end
+  end
+
+  describe '#empty?' do
+    context 'in multi-reader mode' do
+      it 'returns true if all readers are empty' do
+      end
+    end
+
+    context 'in single-reader mode' do
+      it 'returns true if no samples are available for reading' do
+
+      end
     end
   end
 

--- a/spec/lib/mb/sound/circular_buffer_spec.rb
+++ b/spec/lib/mb/sound/circular_buffer_spec.rb
@@ -1,6 +1,7 @@
-RSpec.describe(MB::Sound::CircularBuffer) do
-  it 'can read and write data' do
-    cbuf = MB::Sound::CircularBuffer.new(buffer_size: 7)
+RSpec.describe(MB::Sound::CircularBuffer, :aggregate_failures) do
+  let(:cbuf) { MB::Sound::CircularBuffer.new(buffer_size: 7) }
+
+  it 'maintains length and available values while reading and writing data' do
     expect(cbuf.buffer_size).to eq(7)
 
     expect(cbuf.write(Numo::SFloat[1, 2, 3])).to eq(3)
@@ -33,11 +34,77 @@ RSpec.describe(MB::Sound::CircularBuffer) do
     expect(cbuf.available).to eq(7)
   end
 
-  pending 'with complex values'
-  pending 'with double precision values'
+  it 'can fill and drain the entire buffer in a single call' do
+    expect { cbuf.write(Numo::SFloat[1,2,3,4,5,6,7]) }.not_to raise_error
+    expect(cbuf.read(7)).to eq(Numo::SFloat[1,2,3,4,5,6,7])
+  end
 
-  pending 'raises errors on buffer underflow and overflow'
+  context 'with complex values' do
+    it 'can write and read complex values' do
+      cbuf.write(Numo::SComplex[1i, 1+1i])
+      expect(cbuf.read(2)).to be_a(Numo::SComplex).and eq(Numo::SComplex[1i, 1+1i])
+    end
+
+    it 'changes buffer type to complex, preserving contents' do
+      cbuf.write(Numo::SFloat[-1, 0])
+
+      cbuf.write(Numo::SComplex[1])
+      expect(cbuf.read(3)).to be_a(Numo::SComplex).and eq(Numo::SComplex[-1, 0, 1])
+
+      cbuf.write(Numo::DComplex[2])
+      expect(cbuf.read(1)).to be_a(Numo::DComplex).and eq(Numo::DComplex[2])
+    end
+
+    it 'never switches back to real after switching to complex' do
+      cbuf.write(Numo::SComplex[1i])
+      cbuf.read(1)
+      cbuf.write(Numo::SFloat[1])
+      expect(cbuf.read(1)).to be_a(Numo::SComplex).and eq(Numo::SComplex[1])
+    end
+  end
+
+  context 'with double precision values' do
+    it 'changes buffer type to double, preserving contents' do
+      cbuf.write(Numo::SFloat[-1, 0])
+
+      cbuf.write(Numo::DFloat[1])
+      expect(cbuf.read(3)).to be_a(Numo::DFloat).and eq(Numo::DFloat[-1, 0, 1])
+    end
+
+    it 'never switches back to single precision after switching to double' do
+      cbuf.write(Numo::DFloat[-1])
+      cbuf.read(1)
+      cbuf.write(Numo::SFloat[1])
+      expect(cbuf.read(1)).to be_a(Numo::DFloat).and eq(Numo::DFloat[1])
+    end
+  end
+
+  describe '#read' do
+    it 'raises an error if reading from an empty buffer' do
+      expect { cbuf.read(1) }.to raise_error(MB::Sound::CircularBuffer::BufferUnderflow)
+    end
+
+    it 'raises an error if reading more data than is available' do
+      cbuf.write(Numo::SFloat[1,2,3,4])
+      expect { cbuf.read(5) }.to raise_error(MB::Sound::CircularBuffer::BufferUnderflow)
+    end
+
+    it 'returns an empty NArray if reading zero samples' do
+      expect(cbuf.read(0)).to eq(Numo::SFloat[])
+      cbuf.write(Numo::DComplex[-1i])
+      expect(cbuf.read(0)).to eq(Numo::DComplex[])
+    end
+  end
+
+  describe '#write' do
+    it 'raises an error if writing more data than will fit in the buffer' do
+      expect { cbuf.write(Numo::SFloat[1,2,3,4,5,6,7,8]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+
+      cbuf.write(Numo::DComplex[1,2])
+      expect { cbuf.write(Numo::SFloat[1,2,3,4,5,6]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+    end
+  end
+
+  # TODO: add specs here if resizing is implemented
   pending 'can be resized'
-  pending 'can be switched from real to complex'
-  pending 'when reading zero samples'
 end

--- a/spec/lib/mb/sound/circular_buffer_spec.rb
+++ b/spec/lib/mb/sound/circular_buffer_spec.rb
@@ -194,12 +194,15 @@ RSpec.describe(MB::Sound::CircularBuffer, :aggregate_failures) do
         r1 = cbuf.reader
         r2 = cbuf.reader(3)
 
-        expect { cbuf.write(Numo::SFloat[1,2,3,4]) }.not_to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
+        expect { cbuf.write(Numo::SFloat[1,2,3,4]) }.not_to raise_error
+
+        expect(r1.read(2)).to eq(Numo::SFloat[1,2])
+        expect(r2.read(4)).to eq(Numo::SFloat[0,0,0,1])
       end
 
       it 'raises an error if the write would pass any of the read positions' do
-        r1 = cbuf.reader
-        r2 = cbuf.reader(3)
+        _r1 = cbuf.reader
+        _r2 = cbuf.reader(3)
 
         expect { cbuf.write(Numo::SFloat[1,2,3,4,5]) }.to raise_error(MB::Sound::CircularBuffer::BufferOverflow)
       end

--- a/spec/lib/mb/sound/circular_buffer_spec.rb
+++ b/spec/lib/mb/sound/circular_buffer_spec.rb
@@ -39,4 +39,5 @@ RSpec.describe(MB::Sound::CircularBuffer) do
   pending 'raises errors on buffer underflow and overflow'
   pending 'can be resized'
   pending 'can be switched from real to complex'
+  pending 'when reading zero samples'
 end

--- a/spec/lib/mb/sound/circular_buffer_spec.rb
+++ b/spec/lib/mb/sound/circular_buffer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe(MB::Sound::CircularBuffer) do
     expect(cbuf.read(4)).to eq(Numo::SFloat[1,2,3,4])
     expect(cbuf.length).to eq(1)
     expect(cbuf.available).to eq(6)
-    
+
     expect(cbuf.write(Numo::SFloat[-1, -2, -3, -4, -5, -6])).to eq(7)
     expect(cbuf.length).to eq(7)
     expect(cbuf.available).to eq(0)

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -111,6 +111,9 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter, :aggregate_failures) do
     # FIXME: right now any internal buffer size must be an exact factor of the
     # upstream input's buffer size, or else the input will have to be read
     # twice and the two channels will get out of sync.
+    # TODO: IOSampleMixin could use a circular buffer for each channel, so that
+    # the extra channels are just written to their buffer when one channel is
+    # sampled twice in a row.
     pending 'with split inputs that reset themselves when re-sampled' do
       ai = MB::Sound::ArrayInput.new(
         data: [

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter) do
     pending 'with a very large number of iterations'
   end
 
+  describe '#sources' do
+    it 'returns the upstream as its sole source' do
+      source = 5.constant
+      chain = source.with_buffer(37)
+      expect(chain).to be_a(MB::Sound::GraphNode::BufferAdapter)
+      expect(chain.sources).to eq([source])
+    end
+  end
+
   pending 'when switching from real to complex'
   pending 'when resizing downstream count'
   pending 'when resizing upstream count'

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -130,11 +130,12 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter, :aggregate_failures) do
     # upstream Tee's buffer size, or else the tee will sample the upstream
     # twice and discard data for the other branches
     # TODO: Tee could use a circular buffer for each channel like
-    # IOSampleMixin, so that the extra channels are just written to their
-    # buffer when one channel is sampled twice in a row.
-    # Funnily enough, this fix for Tee (already applied to IOSampleMixin) kind
-    # of makes BufferAdapter unnecessary.
-    pending 'can buffer one branch of a tee'
+    # IOSampleMixin (or CircularBuffer could be given a multi-reader
+    # interface), so that the extra channels are just written to their buffer
+    # when one channel is sampled twice in a row.  Funnily enough, this fix for
+    # Tee (already applied to IOSampleMixin) kind of makes BufferAdapter
+    # unnecessary.
+    pending 'can use different buffers on different branches of a tee'
   end
 
   describe '#sources' do

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -135,7 +135,19 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter, :aggregate_failures) do
     # when one channel is sampled twice in a row.  Funnily enough, this fix for
     # Tee (already applied to IOSampleMixin) kind of makes BufferAdapter
     # unnecessary.
-    pending 'can use different buffers on different branches of a tee'
+    it 'can use different buffers on different branches of a tee' do
+      t1, t2 = 1.constant.tee
+      expect(t1).to receive(:sample).with(17).twice.and_call_original
+      expect(t2).to receive(:sample).with(11).exactly(3).times.and_call_original
+
+      b1 = t1.with_buffer(17)
+      b2 = t2.with_buffer(11)
+
+      expect(b1.sample(24)).to eq(Numo::SFloat.ones(24))
+      expect(b1.sample(3)).to eq(Numo::SFloat[1,1,1])
+
+      expect(b2.sample(23)).to eq(Numo::SFloat.ones(23))
+    end
   end
 
   describe '#sources' do

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter) do
 
     pending 'with values that are common factors'
     pending 'with a very large number of iterations'
+
+    # FIXME: right now any internal buffer size must be an exact factor of the
+    # upstream input's buffer size, or else the input will have to be read
+    # twice and the two channels will get out of sync.
+    pending 'with split inputs that reset themselves when re-sampled'
   end
 
   describe '#sources' do

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -35,4 +35,5 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter) do
   pending 'when switching from real to complex'
   pending 'when resizing downstream count'
   pending 'when resizing upstream count'
+  pending 'when the upstream is empty or nil'
 end

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter) do
 
     it 'shuts down cleanly when upstream returns less than expected' do
       us = double(MB::Sound::GraphNode)
-      expect(us).to receive(:sample).with(4).exactly(3).times.and_return(Numo::SFloat[1,2,3,4], Numo::SFloat[5,6,7], nil)
+      expect(us).to receive(:sample).with(4).exactly(4).times.and_return(Numo::SFloat[1,2,3,4], Numo::SFloat[5,6,7], nil)
 
       b = MB::Sound::GraphNode::BufferAdapter.new(upstream: us, upstream_count: 4)
       expect(b.sample(3)).to eq(Numo::SFloat[1,2,3])

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -108,13 +108,7 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter, :aggregate_failures) do
       expect(b.sample(3)).to eq(Numo::SFloat[-1,-1,-1])
     end
 
-    # FIXME: right now any internal buffer size must be an exact factor of the
-    # upstream input's buffer size, or else the input will have to be read
-    # twice and the two channels will get out of sync.
-    # TODO: IOSampleMixin could use a circular buffer for each channel, so that
-    # the extra channels are just written to their buffer when one channel is
-    # sampled twice in a row.
-    pending 'with split inputs that reset themselves when re-sampled' do
+    it 'can buffer split inputs' do
       ai = MB::Sound::ArrayInput.new(
         data: [
           Numo::SFloat[1,2,3,4,5,6,7,8,9,10],
@@ -131,6 +125,16 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter, :aggregate_failures) do
       expect(l.sample(5)).to eq(Numo::SFloat[6,7,8,9,10])
       expect(r.sample(5)).to eq(Numo::SFloat[4,3,2,1,0])
     end
+
+    # FIXME: right now any internal buffer size must be an exact factor of the
+    # upstream Tee's buffer size, or else the tee will sample the upstream
+    # twice and discard data for the other branches
+    # TODO: Tee could use a circular buffer for each channel like
+    # IOSampleMixin, so that the extra channels are just written to their
+    # buffer when one channel is sampled twice in a row.
+    # Funnily enough, this fix for Tee (already applied to IOSampleMixin) kind
+    # of makes BufferAdapter unnecessary.
+    pending 'can buffer one branch of a tee'
   end
 
   describe '#sources' do

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -1,20 +1,92 @@
 RSpec.describe(MB::Sound::GraphNode::BufferAdapter) do
   describe '#sample' do
+    let(:upstream) { 42.constant }
+
     it 'can read more samples than the upstream count' do
-      upstream = 42.constant
       expect(upstream).to receive(:sample).twice.with(13).and_call_original
       b = MB::Sound::GraphNode::BufferAdapter.new(upstream: upstream, upstream_count: 13)
       expect(b.sample(21)).to eq(Numo::SFloat.zeros(21).fill(42))
     end
 
     it 'can read fewer samples than the upstream count' do
-      upstream = 42.constant
       expect(upstream).to receive(:sample).with(17).and_call_original
       b = MB::Sound::GraphNode::BufferAdapter.new(upstream: upstream, upstream_count: 17)
       expect(b.sample(6)).to eq(Numo::SFloat.zeros(6).fill(42))
     end
 
-    pending 'with values that are common factors'
+    it 'behaves well when the downstream size is a factor of the upstream size' do
+      expect(upstream).to receive(:sample).with(24).twice.and_call_original
+      b = upstream.with_buffer(24)
+      6.times do
+        expect(b.sample(8)).to eq(Numo::SFloat.zeros(8).fill(42))
+      end
+    end
+
+    it 'behaves well when the downstream size is a multiple of the upstream size' do
+      expect(upstream).to receive(:sample).with(8).exactly(6).times.and_call_original
+      b = upstream.with_buffer(8)
+      2.times do
+        expect(b.sample(24)).to eq(Numo::SFloat.zeros(24).fill(42))
+      end
+    end
+
+    it 'behaves well when the downstream size is smaller and not a factor' do
+      expect(upstream).to receive(:sample).with(41).twice.and_call_original
+      b = upstream.with_buffer(41)
+      6.times do
+        expect(b.sample(13)).to eq(Numo::SFloat.zeros(13).fill(42))
+      end
+    end
+
+    it 'behaves well when the downstream size is larger and not a multiple' do
+      expect(upstream).to receive(:sample).with(13).exactly(3).times.and_call_original
+      b = upstream.with_buffer(13)
+      2.times do
+        expect(b.sample(17)).to eq(Numo::SFloat.zeros(17).fill(42))
+      end
+    end
+
+    it 'can switch from real to complex' do
+      cplx = 10.constant.for(0.001).and_then(-5i.constant.for(0.002))
+      b = cplx.with_buffer(46)
+      expect(b.sample(44)).to eq(Numo::SFloat.zeros(44).fill(10))
+      expect(b.sample(8)).to eq(Numo::SComplex[10, 10, 10, 10, -5i, -5i, -5i, -5i])
+    end
+
+    it 'can handle changing downstream sizes' do
+      expect(upstream).to receive(:sample).with(12).twice.and_call_original
+      b = upstream.with_buffer(12)
+      expect(b.sample(9)).to eq(Numo::SFloat.zeros(9).fill(42))
+      expect(b.sample(13)).to eq(Numo::SFloat.zeros(13).fill(42))
+      expect(b.sample(2)).to eq(Numo::SFloat.zeros(2).fill(42))
+    end
+
+    it 'shuts down cleanly when the upstream returns nil' do
+      b = upstream.for(4.0 / 48000).with_buffer(4)
+      expect(b.sample(4)).to eq(Numo::SFloat[42, 42, 42, 42])
+      expect(b.sample(4)).to eq(nil)
+    end
+
+    it 'shuts down cleanly when the upstream returns empty' do
+      us = double(MB::Sound::GraphNode)
+      expect(us).to receive(:sample).with(4).twice.and_return(Numo::SFloat[1,2,3,4], Numo::SFloat[])
+
+      b = MB::Sound::GraphNode::BufferAdapter.new(upstream: us, upstream_count: 4)
+      expect(b.sample(4)).to eq(Numo::SFloat[1,2,3,4])
+      expect(b.sample(4)).to eq(nil)
+    end
+
+    it 'shuts down cleanly when upstream returns less than expected' do
+      us = double(MB::Sound::GraphNode)
+      expect(us).to receive(:sample).with(4).exactly(3).times.and_return(Numo::SFloat[1,2,3,4], Numo::SFloat[5,6,7], nil)
+
+      b = MB::Sound::GraphNode::BufferAdapter.new(upstream: us, upstream_count: 4)
+      expect(b.sample(3)).to eq(Numo::SFloat[1,2,3])
+      expect(b.sample(3)).to eq(Numo::SFloat[4,5,6])
+      expect(b.sample(3)).to eq(Numo::SFloat[7])
+      expect(b.sample(3)).to eq(nil)
+    end
+
     pending 'with a very large number of iterations'
 
     # FIXME: right now any internal buffer size must be an exact factor of the
@@ -31,9 +103,4 @@ RSpec.describe(MB::Sound::GraphNode::BufferAdapter) do
       expect(chain.sources).to eq([source])
     end
   end
-
-  pending 'when switching from real to complex'
-  pending 'when resizing downstream count'
-  pending 'when resizing upstream count'
-  pending 'when the upstream is empty or nil'
 end

--- a/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
+++ b/spec/lib/mb/sound/graph_node/buffer_adapter_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe(MB::Sound::GraphNode::BufferAdapter) do
+  describe '#sample' do
+    it 'can read more samples than the upstream count' do
+      upstream = 42.constant
+      expect(upstream).to receive(:sample).twice.with(13).and_call_original
+      b = MB::Sound::GraphNode::BufferAdapter.new(upstream: upstream, upstream_count: 13)
+      expect(b.sample(21)).to eq(Numo::SFloat.zeros(21).fill(42))
+    end
+
+    it 'can read fewer samples than the upstream count' do
+      upstream = 42.constant
+      expect(upstream).to receive(:sample).with(17).and_call_original
+      b = MB::Sound::GraphNode::BufferAdapter.new(upstream: upstream, upstream_count: 17)
+      expect(b.sample(6)).to eq(Numo::SFloat.zeros(6).fill(42))
+    end
+
+    pending 'with values that are common factors'
+    pending 'with a very large number of iterations'
+  end
+
+  pending 'when switching from real to complex'
+  pending 'when resizing downstream count'
+  pending 'when resizing upstream count'
+end

--- a/spec/lib/mb/sound/graph_node/complex_node_spec.rb
+++ b/spec/lib/mb/sound/graph_node/complex_node_spec.rb
@@ -1,46 +1,57 @@
 RSpec.describe(MB::Sound::GraphNode::ComplexNode, :aggregate_failures) do
-  test_values = {
-    Numo::SComplex[1, -1i, 0.5+0.5i, 0] => {
-      real: Numo::SFloat[1, 0, 0.5, 0],
-      imag: Numo::SFloat[0, -1, 0.5, 0],
-      abs: Numo::SFloat[1, 1, Math.sqrt(2) / 2, 0],
-      arg: Numo::SFloat[0, -Math::PI / 2, Math::PI / 4, 0],
-    },
-    Numo::DComplex[1, -1i, 0.5+0.5i, 0] => {
-      real: Numo::DFloat[1, 0, 0.5, 0],
-      imag: Numo::DFloat[0, -1, 0.5, 0],
-      abs: Numo::DFloat[1, 1, Math.sqrt(2) / 2, 0],
-      arg: Numo::DFloat[0, -Math::PI / 2, Math::PI / 4, 0],
-    },
-    Numo::SFloat[4, -4, 0] => {
-      real: Numo::SFloat[4, -4, 0],
-      imag: Numo::SFloat[0, 0, 0],
-      abs: Numo::SFloat[4, 4, 0],
-      arg: Numo::SFloat[0, Math::PI, 0],
-    },
-    Numo::DFloat[4, -4, 0] => {
-      real: Numo::DFloat[4, -4, 0],
-      imag: Numo::DFloat[0, 0, 0],
-      abs: Numo::DFloat[4, 4, 0],
-      arg: Numo::DFloat[0, Math::PI, 0],
-    },
-  }
+  describe '#sample' do
+    test_values = {
+      Numo::SComplex[1, -1i, 0.5+0.5i, 0] => {
+        real: Numo::SFloat[1, 0, 0.5, 0],
+        imag: Numo::SFloat[0, -1, 0.5, 0],
+        abs: Numo::SFloat[1, 1, Math.sqrt(2) / 2, 0],
+        arg: Numo::SFloat[0, -Math::PI / 2, Math::PI / 4, 0],
+      },
+      Numo::DComplex[1, -1i, 0.5+0.5i, 0] => {
+        real: Numo::DFloat[1, 0, 0.5, 0],
+        imag: Numo::DFloat[0, -1, 0.5, 0],
+        abs: Numo::DFloat[1, 1, Math.sqrt(2) / 2, 0],
+        arg: Numo::DFloat[0, -Math::PI / 2, Math::PI / 4, 0],
+      },
+      Numo::SFloat[4, -4, 0] => {
+        real: Numo::SFloat[4, -4, 0],
+        imag: Numo::SFloat[0, 0, 0],
+        abs: Numo::SFloat[4, 4, 0],
+        arg: Numo::SFloat[0, Math::PI, 0],
+      },
+      Numo::DFloat[4, -4, 0] => {
+        real: Numo::DFloat[4, -4, 0],
+        imag: Numo::DFloat[0, 0, 0],
+        abs: Numo::DFloat[4, 4, 0],
+        arg: Numo::DFloat[0, Math::PI, 0],
+      },
+    }
 
-  test_values.each do |input, cases|
-    context "when given a #{input.class}" do
-      cases.each do |mode, expected|
-        context "when mode is #{mode}" do
-          it 'returns expected outputs for given inputs' do
-            chain = MB::Sound::ArrayInput.new(data: [input]).send(mode)
-            expect(chain).to be_a(MB::Sound::GraphNode::ComplexNode)
-            expect(chain.mode).to eq(mode)
+    test_values.each do |input, cases|
+      context "when given a #{input.class}" do
+        cases.each do |mode, expected|
+          context "when mode is #{mode}" do
+            it 'returns expected outputs for given inputs' do
+              chain = MB::Sound::ArrayInput.new(data: [input]).send(mode)
+              expect(chain).to be_a(MB::Sound::GraphNode::ComplexNode)
+              expect(chain.mode).to eq(mode)
 
-            result = chain.sample(input.length)
-            expect(result).to be_a(expected.class)
-            expect(result).to eq(expected)
+              result = chain.sample(input.length)
+              expect(result).to be_a(expected.class)
+              expect(result).to eq(expected)
+            end
           end
         end
       end
+    end
+  end
+
+  describe '#sources' do
+    it 'returns the input as its sole source' do
+      source = 5.constant
+      chain = source.real
+      expect(chain).to be_a(MB::Sound::GraphNode::ComplexNode)
+      expect(chain.sources).to eq([source])
     end
   end
 end

--- a/spec/lib/mb/sound/graph_node/constant_spec.rb
+++ b/spec/lib/mb/sound/graph_node/constant_spec.rb
@@ -45,4 +45,13 @@ RSpec.describe(MB::Sound::GraphNode::Constant) do
       expect(c.sample(480)).to eq(Numo::SComplex.zeros(480).fill(1+1i))
     end
   end
+
+  context 'with a duration set' do
+    it 'returns only the requested length of data' do
+      c = 1.constant(rate: 1).for(10)
+      expect(c.sample(6).length).to eq(6)
+      expect(c.sample(6).length).to eq(4)
+      expect(c.sample(1)).to eq(nil)
+    end
+  end
 end

--- a/spec/lib/mb/sound/graph_node/input_channel_split_spec.rb
+++ b/spec/lib/mb/sound/graph_node/input_channel_split_spec.rb
@@ -11,19 +11,33 @@ RSpec.describe(MB::Sound::GraphNode::InputChannelSplit) do
     expect(r).to eq(nil)
   end
 
-  describe 'InputChannelNode#sample' do
+  describe '::InputChannelNode#sample' do
     it 'returns different data when channels differ' do
       l, r = MB::Sound.file_input('sounds/synth0.flac').split
-      a = l.sample(800)
-      b = r.sample(800)
+      a = l.sample(800).dup
+      b = r.sample(800).dup
       expect(a).not_to eq(b)
     end
 
     it 'returns different data on subsequent reads' do
       l, _ = MB::Sound.file_input('sounds/synth0.flac').split(max_channels: 1)
-      a = l.sample(800)
-      b = l.sample(800)
+      a = l.sample(800).dup
+      b = l.sample(800).dup
       expect(a).not_to eq(b)
+    end
+
+    it 'can be called more than once for one channel without calling another channel' do
+      ai = MB::Sound::ArrayInput.new(data: [Numo::SFloat[1,2,3,4,5], Numo::SFloat[5,4,3,2,1]], buffer_size: 2)
+      l, r = ai.split
+
+      expect(l.sample(5)).to eq(Numo::SFloat[1,2,3,4,5])
+      expect(r.sample(5)).to eq(Numo::SFloat[5,4,3,2,1])
+    end
+
+    it "raises an error if one channel's buffer overflows" do
+      l, _ = MB::Sound::NullInput.new(channels: 2, buffer_size: 800).split
+      l.sample(48000)
+      expect { l.sample(1) }.to raise_error(MB::Sound::GraphNode::InputChannelSplit::ChannelBufferOverflow)
     end
   end
 end

--- a/spec/lib/mb/sound/graph_node/input_channel_split_spec.rb
+++ b/spec/lib/mb/sound/graph_node/input_channel_split_spec.rb
@@ -39,5 +39,11 @@ RSpec.describe(MB::Sound::GraphNode::InputChannelSplit) do
       l.sample(48000)
       expect { l.sample(1) }.to raise_error(MB::Sound::GraphNode::InputChannelSplit::ChannelBufferOverflow)
     end
+
+    it 'returns nil when the input is out of data' do
+      l = MB::Sound::NullInput.new(channels: 1, length: 5, buffer_size: 800).split[0]
+      expect(l.sample(50)).to eq(Numo::SFloat[0,0,0,0,0])
+      expect(l.sample(1)).to eq(nil)
+    end
   end
 end

--- a/spec/lib/mb/sound/graph_node/multiplier_spec.rb
+++ b/spec/lib/mb/sound/graph_node/multiplier_spec.rb
@@ -35,7 +35,16 @@ RSpec.describe(MB::Sound::GraphNode::Multiplier) do
       expect(ss.sample(123)).to eq(Numo::SFloat.zeros(123).fill(1.5))
     end
 
-    pending 'with mismatched buffer sizes'
+    it 'raises an error if upstream nodes give different buffer sizes' do
+      inp_a = double(MB::Sound::GraphNode)
+      inp_b = double(MB::Sound::GraphNode)
+      allow(inp_a).to receive(:sample).and_return(Numo::SFloat[1,2,3,4])
+      allow(inp_b).to receive(:sample).and_return(Numo::SFloat[1,2,3,4,5])
+
+      m = MB::Sound::GraphNode::Multiplier.new(inp_a, inp_b)
+      expect { m.sample(4) }.to raise_error(/Input 1.*asked/)
+      expect { m.sample(5) }.to raise_error(/Input 0.*asked/)
+    end
 
     it 'returns the same buffer object if size and data type have not changed' do
       ss = MB::Sound::GraphNode::Multiplier.new([1, 0.hz.square.at(0.5).oscillator])

--- a/spec/lib/mb/sound/graph_node/multiplier_spec.rb
+++ b/spec/lib/mb/sound/graph_node/multiplier_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe(MB::Sound::GraphNode::Multiplier) do
       expect(ss.sample(123)).to eq(Numo::SFloat.zeros(123).fill(1.5))
     end
 
+    pending 'with mismatched buffer sizes'
+
     it 'returns the same buffer object if size and data type have not changed' do
       ss = MB::Sound::GraphNode::Multiplier.new([1, 0.hz.square.at(0.5).oscillator])
       a = ss.sample(100)

--- a/spec/lib/mb/sound/graph_node/node_sequence_spec.rb
+++ b/spec/lib/mb/sound/graph_node/node_sequence_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe(MB::Sound::GraphNode::NodeSequence) do
   it 'can be constructed by DSL' do
     # Tones read full buffers always
+    # TODO: prevent Tone from padding lengths when it's used in a sequence like this?
     seq = 0.hz.square.at(5).for(7.0 / 48000).and_then(0.hz.square.at(4).for(4.0 / 48000), Numo::SFloat[-6, -5, -4])
     expect(seq.sample(5)).to eq(Numo::SFloat[5, 5, 5, 5, 5])
     expect(seq.sample(5)).to eq(Numo::SFloat[5, 5, 5, 5, 5])
@@ -10,13 +11,14 @@ RSpec.describe(MB::Sound::GraphNode::NodeSequence) do
   end
 
   describe '#sample' do
-    it 'returns nil after a single source has finished' do
+    it 'returns nil after a solitary source has finished' do
       seq = MB::Sound::GraphNode::NodeSequence.new([MB::Sound::ArrayInput.new(data: [Numo::SFloat[1,2,3,4]])])
       expect(seq.sample(7)).to eq(Numo::SFloat[1,2,3,4,0,0,0])
       expect(seq.sample(7)).to eq(nil)
     end
 
     it 'returns data from each source in sequence' do
+      # TODO: prevent ArrayInput/IOSampleMixin from padding when it's used in a sequence like this?
       seq = MB::Sound::GraphNode::NodeSequence.new([
         MB::Sound::ArrayInput.new(data: [Numo::SFloat[1, 2, 3, 4, 5, 6]]),
         MB::Sound::ArrayInput.new(data: [Numo::SFloat[-1, -2, -3]]),
@@ -28,6 +30,50 @@ RSpec.describe(MB::Sound::GraphNode::NodeSequence) do
       expect(seq.sample(4)).to eq(Numo::SFloat[-1, -2, -3, 0])
       expect(seq.sample(4)).to eq(Numo::SFloat[5, 10, 15, 20])
       expect(seq.sample(4)).to eq(nil)
+    end
+
+    it 'does not zero pad sources that return short reads until the very end' do
+      seq = 5.constant.for(3.0 / 48000).and_then(2.constant.for(7.0 / 48000), 1.constant.for(4.0 / 48000.0))
+      expect(seq.sample(4)).to eq(Numo::SFloat[5, 5, 5, 2])
+      expect(seq.sample(4)).to eq(Numo::SFloat[2, 2, 2, 2])
+      expect(seq.sample(4)).to eq(Numo::SFloat[2, 2, 1, 1])
+      expect(seq.sample(4)).to eq(Numo::SFloat[1, 1, 0, 0])
+      expect(seq.sample(4)).to eq(nil)
+    end
+
+    it 'can return complex data' do
+      seq = -0.5.constant.for(3.0 / 48000)
+        .and_then((-1 + 1.5i).constant.for(4.0 / 48000))
+
+      expect(seq.sample(2)).to be_a(Numo::SFloat).and eq(Numo::SFloat[-0.5, -0.5])
+      expect(seq.sample(2)).to be_a(Numo::SComplex).and eq(Numo::SComplex[-0.5, -1+1.5i])
+      expect(seq.sample(2)).to be_a(Numo::SComplex).and eq(Numo::SComplex[-1+1.5i, -1+1.5i])
+      expect(seq.sample(2)).to be_a(Numo::SComplex).and eq(Numo::SComplex[-1+1.5i, 0])
+      expect(seq.sample(2)).to eq(nil)
+    end
+  end
+
+  describe '#and_then' do
+    it 'just adds another source to the sequence' do
+      seq = MB::Sound::GraphNode::NodeSequence.new(3.constant.for(3.0 / 48000))
+      expect(seq.sources.length).to eq(1)
+
+      seq2 = seq.and_then(5.constant.for(2.0 / 48000))
+      expect(seq2).to equal(seq)
+      expect(seq.sources.length).to eq(2)
+
+      expect(seq.sample(5)).to eq(Numo::SFloat[3, 3, 3, 5, 5])
+    end
+
+    it 'resumes sample output even if sources were previously exhausted' do
+      seq = MB::Sound::GraphNode::NodeSequence.new(1.constant.for(2.0 / 48000))
+
+      expect(seq.sample(3)).to eq(Numo::SFloat[1, 1, 0])
+      expect(seq.sample(3)).to eq(nil)
+
+      seq.and_then(2.constant.for(1.0 / 48000))
+      expect(seq.sample(3)).to eq(Numo::SFloat[2, 0, 0])
+      expect(seq.sample(3)).to eq(nil)
     end
   end
 end

--- a/spec/lib/mb/sound/graph_node/tee_spec.rb
+++ b/spec/lib/mb/sound/graph_node/tee_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe(MB::Sound::GraphNode::Tee) do
     expect(ref).not_to eq(b2)
   end
 
-  pending 'when the upstream is nil'
-
   it 'zero pads if the source returns less data' do
     source = MB::Sound::ArrayInput.new(data: [Numo::SFloat[]])
     expect(source).to receive(:sample).with(5).and_return(Numo::SFloat[1,2,3,4,5], Numo::SFloat[6,7])
@@ -42,5 +40,35 @@ RSpec.describe(MB::Sound::GraphNode::Tee) do
 
     expect(t1.sample(5)).to eq(Numo::SFloat[6,7,0,0,0])
     expect(t2.sample(5)).to eq(Numo::SFloat[6,7,0,0,0])
+  end
+
+  it 'returns nil if the source returns nil' do
+    source = double(MB::Sound::GraphNode)
+    allow(source).to receive(:sample).and_return(Numo::SFloat[1,2,3], nil)
+
+    t1, t2 = MB::Sound::GraphNode::Tee.new(source).branches
+
+    expect(t1.sample(3)).to eq(Numo::SFloat[1,2,3])
+    expect(t2.sample(3)).to eq(Numo::SFloat[1,2,3])
+
+    expect(t1.sample(3)).to eq(nil)
+    expect(t2.sample(3)).to eq(nil)
+    expect(t1.sample(3)).to eq(nil)
+    expect(t2.sample(3)).to eq(nil)
+  end
+
+  it 'returns nil if the source returns empty' do
+    source = double(MB::Sound::GraphNode)
+    allow(source).to receive(:sample).and_return(Numo::SFloat[1,2,3], Numo::SFloat[])
+
+    t1, t2 = MB::Sound::GraphNode::Tee.new(source).branches
+
+    expect(t1.sample(3)).to eq(Numo::SFloat[1,2,3])
+    expect(t2.sample(3)).to eq(Numo::SFloat[1,2,3])
+
+    expect(t1.sample(3)).to eq(nil)
+    expect(t2.sample(3)).to eq(nil)
+    expect(t1.sample(3)).to eq(nil)
+    expect(t2.sample(3)).to eq(nil)
   end
 end

--- a/spec/lib/mb/sound/graph_node/tee_spec.rb
+++ b/spec/lib/mb/sound/graph_node/tee_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe(MB::Sound::GraphNode::Tee) do
   it 'raises an error if one branch gets too far out of sync' do
     source = 1.constant
 
-    t1, t2 = source.tee
+    t1, _t2 = source.tee
 
     expect(t1.sample(47999)).to eq(Numo::SFloat.zeros(47999).fill(1))
     expect(t1.sample(1)).to eq(Numo::SFloat[1])

--- a/spec/lib/mb/sound/graph_node/tee_spec.rb
+++ b/spec/lib/mb/sound/graph_node/tee_spec.rb
@@ -27,4 +27,6 @@ RSpec.describe(MB::Sound::GraphNode::Tee) do
     expect(a2).to eq(b2)
     expect(ref).not_to eq(b2)
   end
+
+  pending 'when the upstream is nil'
 end


### PR DESCRIPTION
This is a project to add a "buffer adapter" to the node graph.  This allows different parts of the node graph to run with different buffer sizes, which is useful for graphs with feedback.  For example, we can make an echo effect with a delay, a gain, and feedback.  The shortest feedback path we can have is the buffer size, so having a shorter buffer for the feedback section allows shorter delay times at the expense of increased CPU usage.

This PR also adds a buffer management helper to simplify graph nodes that need to keep an internal buffer.

The flanger and tape delay effects in bin/ have been updated to demonstrate how the buffer adapter works.

- [x] Implement buffer adapter
- [x] Add buffer adapter example in bin/
- [x] Implement pending specs
  - [x] `CircularBuffer`
  - [x] `BufferAdapter`
  - [x] `Multiplier`
  - [x] `Tee`
- [x] Support split inputs with coprime buffer sizes
- [x] Support tees with coprime buffer sizes??