### PR TITLE
Fix sound.rb with pry-byebug 3.10+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
   specs:
     bigdecimal (3.1.9)
     builder (3.2.4)
-    byebug (11.1.3)
+    byebug (12.0.0)
     cmath (1.0.0)
     coderay (1.1.3)
     csv (3.3.3)
@@ -69,9 +69,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
     pry-doc (1.5.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
@@ -118,7 +118,7 @@ DEPENDENCIES
   mb-sound-jackffi (>= 0.0.21.usegit)!
   mb-util (>= 0.1.22.usegit)!
   pry (~> 0.14.0)
-  pry-byebug (~> 3.10.0)
+  pry-byebug (~> 3.11.0)
   pry-doc
   rake (~> 13.0.1)
   rake-compiler (~> 1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-sound (0.8.2.usegit)
+    mb-sound (0.8.3.usegit)
       cmath (~> 1.0.0)
       csv (~> 3.3, >= 3.3.3)
       mb-math (>= 0.2.2.usegit)

--- a/lib/mb/sound/version.rb
+++ b/lib/mb/sound/version.rb
@@ -1,5 +1,5 @@
 module MB
   module Sound
-    VERSION = "0.8.2.usegit"
+    VERSION = "0.8.3.usegit"
   end
 end

--- a/mb-sound.gemspec
+++ b/mb-sound.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
 
   # Interactive command line gems
   spec.add_development_dependency 'pry', '~> 0.14.0'
-  spec.add_development_dependency 'pry-byebug', '~> 3.10.0'
+  spec.add_development_dependency 'pry-byebug', '~> 3.11.0'
   spec.add_development_dependency 'pry-doc'
 
   # Testing gems


### PR DESCRIPTION
As described in https://github.com/mike-bourgeous/mb-sound/issues/37, pry-byebug 3.10 changed how it patches into Pry to work with Pry 0.14.  That broke `bin/sound.rb`, causing it to exit without starting Pry.

This workaround restores the color prompt, default `MB::Sound` context, and colorizing exception handler to `bin/sound.rb`.