### PR TITLE
Prevent envelope duplicates from writing to original buffer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-sound (0.8.5.usegit)
+    mb-sound (0.8.6.usegit)
       cmath (~> 1.0.0)
       csv (~> 3.3, >= 3.3.3)
       mb-math (>= 0.2.2.usegit)

--- a/ext/mb/fast_sound/extconf.rb
+++ b/ext/mb/fast_sound/extconf.rb
@@ -10,6 +10,6 @@ na = Gem.loaded_specs['numo-narray']
 raise "Could not find the numo-narray Gem; try running with Bundler" if na.nil?
 raise 'Could not find narray.h' unless find_header('numo/narray.h', File.join(na.extension_dir, 'numo'))
 
-with_cflags("#{$CFLAGS} -O3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE=700 -D_ISOC99_SOURCE -D_GNU_SOURCE") do
+with_cflags("#{$CFLAGS} -O3 -ggdb3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE=700 -D_ISOC99_SOURCE -D_GNU_SOURCE") do
   create_makefile('mb/fast_sound')
 end

--- a/lib/mb/sound/adsr_envelope.rb
+++ b/lib/mb/sound/adsr_envelope.rb
@@ -318,6 +318,8 @@ module MB
       # of the original envelope.
       def dup(rate = @rate)
         e = super()
+        e.instance_variable_set(:@buf, @buf.dup)
+        e.named("#{graph_node_name} (dup)")
         e.instance_variable_set(:@peak, 1.0) unless active?
         e.instance_variable_set(:@rate, rate.to_f)
         e.instance_variable_set(:@filter, @filter.center_frequency.hz.at_rate(rate).lowpass1p)

--- a/lib/mb/sound/adsr_envelope.rb
+++ b/lib/mb/sound/adsr_envelope.rb
@@ -128,6 +128,8 @@ module MB
         @value = 0
         @auto_release = auto_release
         @on = true
+
+        self
       end
 
       # Starts the release phase of the envelope, if it is not already in the
@@ -142,6 +144,8 @@ module MB
           self.time = @release_start
           @on = false
         end
+
+        self
       end
 
       # Turn off the envelope, reset the filter, and disable any auto-release
@@ -153,6 +157,7 @@ module MB
         @on = false
         @auto_release = nil
         @filter.reset(0)
+        self
       end
 
       # Jump the envelope to the given time.  This does not reset the internal
@@ -333,6 +338,8 @@ module MB
         @release_time = release_time.to_f
         @release_start = @attack_time + @decay_time
         @total = @attack_time + @decay_time + @release_time
+
+        self
       end
 
       # Advances the internal clock by the given number of +samples+.

--- a/lib/mb/sound/adsr_envelope.rb
+++ b/lib/mb/sound/adsr_envelope.rb
@@ -236,9 +236,10 @@ module MB
 
       def sample_ruby_c(count, filter: true)
         if count
-          buf = Numo::SFloat.zeros(count).map { sample_one_c(filter: filter) }
-          return nil if @auto_release && !@on && buf.max < -100.db
-          return buf
+          setup_buffer(length: count)
+          @buf.inplace.map { sample_one_c(filter: filter) }
+          return nil if @auto_release && !@on && @buf.max < -100.db
+          return @buf
         end
 
         return sample_one_c(filter: filter)
@@ -267,9 +268,10 @@ module MB
 
       def sample_ruby(count = nil, filter: true)
         if count
-          buf = Numo::SFloat.zeros(count).map { sample_ruby(filter: filter) }
-          return nil if @auto_release && !@on && buf.max < -100.db
-          return buf
+          setup_buffer(length: count)
+          @buf.inplace.map { sample_ruby(filter: filter) }
+          return nil if @auto_release && !@on && @buf.max < -100.db
+          return @buf
         end
 
         if @on

--- a/lib/mb/sound/filter/biquad.rb
+++ b/lib/mb/sound/filter/biquad.rb
@@ -179,12 +179,12 @@ module MB
         # C loop, C math (much faster than pure Ruby)
         def process_c(samples)
           # FIXME: convert to SComplex/DComplex if coefficients are complex
-          samples, @x1, @x2, @y1, @y2 = MB::FastSound.biquad_narray(
+          result, @x1, @x2, @y1, @y2 = MB::FastSound.biquad_narray(
             @b0, @b1, @b2, @a1, @a2,
             [samples, @x1, @x2, @y1, @y2]
           )
 
-          samples
+          result
         end
 
         # Ruby outer loop, C math (slightly faster than pure Ruby)

--- a/lib/mb/sound/graph_node.rb
+++ b/lib/mb/sound/graph_node.rb
@@ -417,11 +417,11 @@ module MB
             def sample(count)
               super(count).tap { |buf|
                 MB::M.with_inplace(buf, false) do |b|
-                  @graph_spies.each do |s|
+                  @graph_spies.each_with_index do |s, idx|
                     begin
                       s.call(b)
                     rescue => e
-                      warn "Spy #{s} raised #{MB::U.highlight(e)}"
+                      warn "Spy #{idx}/#{s} raised #{MB::U.highlight(e)}"
                     end
                   end
                 end

--- a/lib/mb/sound/version.rb
+++ b/lib/mb/sound/version.rb
@@ -1,5 +1,5 @@
 module MB
   module Sound
-    VERSION = "0.8.5.usegit"
+    VERSION = "0.8.6.usegit"
   end
 end

--- a/spec/lib/mb/sound/adsr_envelope_spec.rb
+++ b/spec/lib/mb/sound/adsr_envelope_spec.rb
@@ -196,17 +196,27 @@ RSpec.describe(MB::Sound::ADSREnvelope, :aggregate_failures) do
       dup = env.dup(1000)
       expect(env.sample(800).object_id).not_to eq(dup.sample(800).object_id)
 
+      data = env.sample(800)
+      expect(data.minmax).to eq([0, 0])
+
       dup.sample_all
-      expect(env.sample(100000).minmax).to eq([0, 0])
+      expect(data.minmax).to eq([0, 0])
     end
 
     it 'does not use the same buffer as the original (using vis env)' do
       cenv2 = MB::Sound.adsr(0, 0.2, 0.0, 0.1).reset.named('cenv2')
 
-      expect(cenv2.sample(800).object_id).not_to eq(cenv2.dup.sample(800).object_id)
+      cenv2.sample(800)
+      dup = cenv2.dup(1900)
 
-      # FIXME: can't reproduce bad data in original buffer!
-      expect(cenv2.sample(800).minmax).to eq([0, 0])
+      data = cenv2.sample(800)
+      expect(data.minmax).to eq([0, 0])
+
+      # Detect dup overwriting original buffer
+      dup.sample_all
+      expect(data.minmax).to eq([0, 0])
+
+      expect(cenv2.sample(800).object_id).not_to eq(dup.sample(800).object_id)
     end
   end
 

--- a/spec/lib/mb/sound/adsr_envelope_spec.rb
+++ b/spec/lib/mb/sound/adsr_envelope_spec.rb
@@ -190,6 +190,24 @@ RSpec.describe(MB::Sound::ADSREnvelope, :aggregate_failures) do
       expect(filter_dup.sample_rate).to eq(1500)
       expect(filter.sample_rate).to eq(48000)
     end
+
+    it 'does not use the same buffer as the original' do
+      env.sample(800)
+      dup = env.dup(1000)
+      expect(env.sample(800).object_id).not_to eq(dup.sample(800).object_id)
+
+      dup.sample_all
+      expect(env.sample(100000).minmax).to eq([0, 0])
+    end
+
+    it 'does not use the same buffer as the original (using vis env)' do
+      cenv2 = MB::Sound.adsr(0, 0.2, 0.0, 0.1).reset.named('cenv2')
+
+      expect(cenv2.sample(800).object_id).not_to eq(cenv2.dup.sample(800).object_id)
+
+      # FIXME: can't reproduce bad data in original buffer!
+      expect(cenv2.sample(800).minmax).to eq([0, 0])
+    end
   end
 
   describe '#trigger' do

--- a/spec/lib/mb/sound/adsr_envelope_spec.rb
+++ b/spec/lib/mb/sound/adsr_envelope_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe(MB::Sound::ADSREnvelope, :aggregate_failures) do
             delta = (c - ruby).abs
             expect(MB::M.round(delta, filt ? 6 : 7).max).to eq(0)
           end
+
+          it 'reuses the same buffer' do
+            expect(env.send(m, 500).object_id).to eq(env.send(m, 500).object_id)
+          end
         end
       end
     end

--- a/spec/lib/mb/sound/ffmpeg_input_spec.rb
+++ b/spec/lib/mb/sound/ffmpeg_input_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe MB::Sound::FFMPEGInput do
         expect { result = input.close }.not_to raise_exception
       end
 
-      expect(delay).to be < 1
+      expect(delay).to be < 3
       expect(result).to be_a(Process::Status)
 
       expect { input.read(1) }.to raise_exception(IOError)


### PR DESCRIPTION
When I tested my synthesizer code during one of my livestreams, the oscillators were sounding without any keys pressed, the audio was glitchy, and nothing was working as it should.  I've now tracked that down to the sample buffer from the envelope generator getting assigned to both the envelope itself and the copy used for displaying the envelope curve on screen.

So whenever an envelope was displayed on screen its output was corrupted with part of the display plot.

## Expected:

![image](https://github.com/user-attachments/assets/ff303583-937e-4752-9bc2-102edf11e418)

## Actual:

![image](https://github.com/user-attachments/assets/c56dfae9-6ad0-461f-a0ce-bc7a436622fb)

----

This PR duplicates the envelope's buffer when the envelope is duplicated and adds tests to ensure the duplication has the expected effect.