### PR TITLE
Benchmark different Ruby versions

### DIFF
--- a/bin/benchmark_ruby_versions.sh
+++ b/bin/benchmark_ruby_versions.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 
+set -e
+
 for version in 2.7 3.0 3.1 3.2 3.3 3.4; do
 	printf "\n\e[1;33m----------------\nRuby ${version}\n----------------\e[0m\n\n"
 
-	printf "\e[1mbundle install\e[0m\n"
+	printf "\n\e[1mruby install\e[0m\n"
+	rvm install ${version}
+	rvm ${version} do rvm gemset create mb-sound
+
+	printf "\n\e[1mbundle install\e[0m\n"
 	rvm ${version}@mb-sound do bundle install
 
-	printf "\e[1mrake clean compile\e[0m\n"
+	printf "\n\e[1mrake clean compile\e[0m\n"
 	rvm ${version}@mb-sound do rake clean compile
 	
-	printf "\e[1mbenchmark\e[0m\n"
+	printf "\n\e[1mbenchmark\e[0m\n"
 	rvm ${version}@mb-sound do bin/node_graph_benchmark.rb --bench
 done

--- a/bin/benchmark_ruby_versions.sh
+++ b/bin/benchmark_ruby_versions.sh
@@ -2,19 +2,26 @@
 
 set -e
 
-for version in 2.7 3.0 3.1 3.2 3.3 3.4; do
-	printf "\n\e[1;33m----------------\nRuby ${version}\n----------------\e[0m\n\n"
+VERSION_LIST="2.7 3.0 3.1 3.2 3.3 3.4"
 
-	printf "\n\e[1mruby install\e[0m\n"
-	rvm install ${version}
-	rvm ${version} do rvm gemset create mb-sound
+for version in $VERSION_LIST; do
+	printf "\n\e[38;5;242m----------------\n Setup ruby ${version}\n----------------\e[0m\n\n"
 
-	printf "\n\e[1mbundle install\e[0m\n"
-	rvm ${version}@mb-sound do bundle install
+	printf "\n\e[38;5;242mruby install\e[0m\n"
+	rvm install ${version} > /dev/null
+	rvm ${version} do rvm gemset create mb-sound > /dev/null
 
-	printf "\n\e[1mrake clean compile\e[0m\n"
-	rvm ${version}@mb-sound do rake clean compile
-	
-	printf "\n\e[1mbenchmark\e[0m\n"
+	printf "\n\e[38;5;242mbundle install\e[0m\n"
+	rvm ${version}@mb-sound do bundle install > /dev/null
+
+	printf "\n\e[38;5;242mrake clean compile\e[0m\n"
+	rvm ${version}@mb-sound do rake clean compile > /dev/null
+
+	printf "\n\e[1;33m------------------\nBenchmark ruby ${version}\n------------------\e[0m\n\n"
+
+	printf "\n\e[1mbenchmark \e[36m$version \e[31mwithout jit\e[0m\n"
 	rvm ${version}@mb-sound do bin/node_graph_benchmark.rb --bench
+
+	printf "\n\e[1mbenchmark \e[36m$version \e[32mwith jit\e[0m\n"
+	RUBYOPT=--jit rvm ${version}@mb-sound do bin/node_graph_benchmark.rb --bench
 done

--- a/bin/benchmark_ruby_versions.sh
+++ b/bin/benchmark_ruby_versions.sh
@@ -4,6 +4,12 @@ set -e
 
 VERSION_LIST="2.7 3.0 3.1 3.2 3.3 3.4"
 
+if [ $# -ge "1" ]; then
+	VERSION_LIST="$*"
+fi
+
+printf "\n\e[1mBenchmarking versions: \e[36m$VERSION_LIST\e[0m\n\n"
+
 for version in $VERSION_LIST; do
 	printf "\n\e[38;5;242m----------------\n Setup ruby ${version}\n----------------\e[0m\n\n"
 

--- a/bin/benchmark_ruby_versions.sh
+++ b/bin/benchmark_ruby_versions.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+for version in 2.7 3.0 3.1 3.2 3.3 3.4; do
+	printf "\n\e[1;33m----------------\nRuby ${version}\n----------------\e[0m\n\n"
+
+	printf "\e[1mbundle install\e[0m\n"
+	rvm ${version}@mb-sound do bundle install
+
+	printf "\e[1mrake clean compile\e[0m\n"
+	rvm ${version}@mb-sound do rake clean compile
+	
+	printf "\e[1mbenchmark\e[0m\n"
+	rvm ${version}@mb-sound do bin/node_graph_benchmark.rb --bench
+done

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -66,6 +66,10 @@ final_r = r.tee.yield_self { |(x, y)|
   flanger.softclip(0.5, 0.99)
 }
 
+envelopes.each do |e|
+  e.trigger(1, auto_release: true)
+end
+
 if ARGV.include?('--bench')
   Benchmark.bmbm do |bench|
     [100, 800, 4000].each do |bufsize|
@@ -92,10 +96,10 @@ if ARGV.include?('--bench')
       end
     end
   end
+elsif ARGV[0]
+  MB::U.prevent_overwrite(ARGV[0], prompt: true)
+  MB::U.headline("Saving benchmark song to #{ARGV[0].inspect}")
+  MB::Sound.write(ARGV[0], [final_l.with_buffer(800), final_r.with_buffer(800)])
 else
-  envelopes.each do |e|
-    e.trigger(1, auto_release: true)
-  end
-
   MB::Sound.play [final_l.with_buffer(800), final_r.with_buffer(800)]
 end

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -3,6 +3,8 @@
 # parts of the GraphNode and Filter code, including processing with complex
 # numbers.
 #
+# Music and code (C)2025 Mike Bourgeous
+#
 # Use --bench to run the benchmark, or no arguments to play the song.
 
 require 'bundler/setup'
@@ -12,7 +14,6 @@ require 'benchmark'
 require 'mb-sound'
 
 abenv = MB::Sound::ADSREnvelope.new(attack_time: 60, decay_time: 30, sustain_level: 0.125, release_time: 90, rate: 48000)
-abenv.trigger(1, auto_release: true)
 
 a = 100.hz.complex_square.forever.at(-13.db).filter(1500.hz.lowpass(quality: 0.5))
 b = 150.hz.ramp.forever.at(-15.db).filter(2600.hz.lowpass(quality: 0.5))
@@ -20,7 +21,6 @@ b = 150.hz.ramp.forever.at(-15.db).filter(2600.hz.lowpass(quality: 0.5))
 ab = (a + b).softclip(0.05, 0.2) * 1.hz.drumramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abenv
 
 cenv = MB::Sound::ADSREnvelope.new(attack_time: 90, decay_time: 60, sustain_level: 1, release_time: 30, rate: 48000)
-cenv.trigger(1, auto_release: true)
 
 c = (
   266.66667.hz.triangle.forever.at(-4.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1) +
@@ -28,7 +28,6 @@ c = (
 ).softclip(0.05, 0.25) * 10.db * cenv
 
 denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 156, sustain_level: 1, release_time: 20, rate: 48000)
-denv.trigger(1, auto_release: true)
 
 d = (
   50.hz.triangle.at(-3.db).forever.filter(150.hz.lowpass1p) *
@@ -36,7 +35,6 @@ d = (
 ).softclip(0.005, 0.25) * 10.db * denv
 
 drumenv = MB::Sound::ADSREnvelope.new(attack_time: 10, decay_time: 160, sustain_level: 1, release_time: 10, rate: 48000)
-drumenv.trigger(1, auto_release: true)
 
 hat = 10000.hz.noise.filter(9000.hz.highpass).filter(15000.hz.lowpass) * 8.hz.drumramp.lfo.at(-4..-25).filter(100.hz.lowpass).db
 kick = 50.hz.at(-3.db).fm(2.hz.drumramp.at(90.to_db..-60).db.filter(100.hz.lowpass)) * 2.hz.drumramp.at(0..-30).db.filter(100.hz.lowpass)
@@ -45,25 +43,52 @@ drums = (hat + kick) * drumenv
 
 graph = ((drums + ab + c + d) * -6.db).softclip(0.25, 0.99)
 
+envelopes = graph.graph.select { |n| n.is_a?(MB::Sound::ADSREnvelope) }
+tones = graph.graph.select { |n| n.is_a?(MB::Sound::Tone) }
+
+m, s = graph.for(180).tee
+
+m1, m2 = m.real.tee
+s1, s2 = s.imag.tee
+
+l = m1 + -6.db * s1
+r = m2 - -6.db * s2
+
+final_l = l.tee.yield_self { |(x, y)|
+  flanger = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.at(0.001..0.008))
+  flanger.softclip(0.5, 0.99)
+}
+final_r = r.tee.yield_self { |(x, y)|
+  flanger = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.with_phase(Math::PI).at(0.001..0.008))
+  flanger.softclip(0.5, 0.99)
+}
+
 if ARGV.include?('--bench')
-  raise 'TODO'
+  Benchmark.bm do |x|
+    [100, 800, 4000].each do |bufsize|
+      # Reset envelopes
+      envelopes.each do |e|
+        e.trigger(1, auto_release: true)
+      end
+
+      # Reset oscillators and constants
+      final_l.for(180)
+      final_r.for(180)
+
+      x.report("bufsize=#{bufsize}") do
+        loop do
+          x = final_l.with_buffer(bufsize).sample(bufsize)
+          y = final_r.with_buffer(bufsize).sample(bufsize)
+
+          break if x.nil? || y.nil?
+        end
+      end
+    end
+  end
 else
-  m, s = graph.for(180).tee
+  envelopes.each do |e|
+    e.trigger(1, auto_release: true)
+  end
 
-  m1, m2 = m.real.tee
-  s1, s2 = s.imag.tee
-
-  l = m1 + -6.db * s1
-  r = m2 - -6.db * s2
-
-  final_l = l.tee.yield_self { |(x, y)|
-    flanger = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.at(0.001..0.008))
-    flanger.softclip(0.5, 0.99).with_buffer(800)
-  }
-  final_r = r.tee.yield_self { |(x, y)|
-    flanger = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.with_phase(Math::PI).at(0.001..0.008))
-    flanger.softclip(0.5, 0.99).with_buffer(800)
-  }
-
-  MB::Sound.play [final_l, final_r]
+  MB::Sound.play [final_l.with_buffer(800), final_r.with_buffer(800)]
 end

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -20,7 +20,7 @@ cenv.trigger(1, auto_release: true)
 c = (
   266.66667.hz.triangle.forever.at(-4.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1) +
   250.hz.complex_triangle.forever.at(-3.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1).with_phase(Math::PI)
-) * cenv
+).softclip(0.05, 0.15) * 6.db * cenv
 
 denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 156, sustain_level: 1, release_time: 20, rate: 48000)
 denv.trigger(1, auto_release: true)
@@ -42,4 +42,8 @@ drums = (hat + kick) * drumenv
 
 graph = ((drums + ab + c + d) * -6.db).softclip(0.25, 0.99)
 
-MB::Sound.play graph.real.for(180).with_buffer(800)
+x, y = graph.tee
+
+effect = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.at(0.001..0.008))
+
+MB::Sound.play effect.real.softclip(0.5, 0.99).for(180).with_buffer(800)

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -6,14 +6,23 @@ require 'benchmark'
 
 require 'mb-sound'
 
-a = 100.hz.complex_square.forever.at(-6.db).filter(1500.hz.lowpass(quality: 0.5))
-b = 150.hz.ramp.forever.at(-7.db).filter(2600.hz.lowpass(quality: 0.5))
-c = 266.66667.hz.triangle.forever.at(-5.db).softclip(0.05, 0.5).filter(900.hz.lowpass1p) *
-  0.1.hz.lfo.at(0..1) +
-  250.hz.complex_triangle.forever.at(-4.db).softclip(0.05, 0.5).filter(900.hz.lowpass1p) *
-  0.1.hz.lfo.at(0..1).with_phase(Math::PI)
+abenv = MB::Sound::ADSREnvelope.new(attack_time: 60, decay_time: 30, sustain_level: 0.125, release_time: 90, rate: 48000)
+abenv.trigger(1, auto_release: true)
 
-denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 60, sustain_level: 1, release_time: 60, rate: 48000)
+a = 100.hz.complex_square.forever.at(-10.db).filter(1500.hz.lowpass(quality: 0.5))
+b = 150.hz.ramp.forever.at(-12.db).filter(2600.hz.lowpass(quality: 0.5))
+
+ab = (a + b) * 1.hz.ramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abenv
+
+cenv = MB::Sound::ADSREnvelope.new(attack_time: 90, decay_time: 60, sustain_level: 1, release_time: 30, rate: 48000)
+cenv.trigger(1, auto_release: true)
+
+c = (
+  266.66667.hz.triangle.forever.at(-4.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1) +
+  250.hz.complex_triangle.forever.at(-3.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1).with_phase(Math::PI)
+) * cenv
+
+denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 156, sustain_level: 1, release_time: 20, rate: 48000)
 denv.trigger(1, auto_release: true)
 
 d = (
@@ -21,12 +30,16 @@ d = (
   4.hz.ramp.lfo.at(0..-30).db.filter(50.hz.lowpass)
 ).softclip(0.005, 0.25) * 10.db * denv
 
-abcenv = MB::Sound::ADSREnvelope.new(attack_time: 60, decay_time: 10, sustain_level: 0.125, release_time: 50, rate: 48000)
-abcenv.trigger(1, auto_release: true)
+drumenv = MB::Sound::ADSREnvelope.new(attack_time: 10, decay_time: 160, sustain_level: 1, release_time: 10, rate: 48000)
+drumenv.trigger(1, auto_release: true)
 
-hat = 10000.hz.noise.filter(9000.hz.highpass).filter(15000.hz.lowpass) * 8.hz.ramp.lfo.at(0..-25).filter(100.hz.lowpass).db
+# FIXME: drum and bass hits don't seem to happen in time; figure out LFO-as-repeating-envelope phasing
+
+hat = 10000.hz.noise.filter(9000.hz.highpass).filter(15000.hz.lowpass) * 8.hz.ramp.lfo.at(-4..-25).filter(100.hz.lowpass).db
 kick = 50.hz.at(-3.db).fm(2.hz.ramp.at(90.to_db..-60).db.filter(100.hz.lowpass)) * 2.hz.ramp.at(0..-30).db.filter(100.hz.lowpass)
 
-graph = (kick + hat + (a + b + c) * 1.hz.ramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abcenv + d).softclip(0.25, 0.99)
+drums = (hat + kick) * drumenv
 
-MB::Sound.play graph.real.for(180)
+graph = ((drums + ab + c + d) * -6.db).softclip(0.25, 0.99)
+
+MB::Sound.play graph.real.for(180).with_buffer(800)

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+# This is a simple algorithmically defined song that exercises several common
+# parts of the GraphNode and Filter code, including processing with complex
+# numbers.
+#
+# Use --bench to run the benchmark, or no arguments to play the song.
 
 require 'bundler/setup'
 
@@ -12,7 +17,7 @@ abenv.trigger(1, auto_release: true)
 a = 100.hz.complex_square.forever.at(-13.db).filter(1500.hz.lowpass(quality: 0.5))
 b = 150.hz.ramp.forever.at(-15.db).filter(2600.hz.lowpass(quality: 0.5))
 
-ab = (a + b) * 1.hz.drumramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abenv
+ab = (a + b).softclip(0.05, 0.2) * 1.hz.drumramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abenv
 
 cenv = MB::Sound::ADSREnvelope.new(attack_time: 90, decay_time: 60, sustain_level: 1, release_time: 30, rate: 48000)
 cenv.trigger(1, auto_release: true)
@@ -20,7 +25,7 @@ cenv.trigger(1, auto_release: true)
 c = (
   266.66667.hz.triangle.forever.at(-4.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1) +
   250.hz.complex_triangle.forever.at(-3.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1).with_phase(Math::PI)
-).softclip(0.05, 0.25) * 15.db * cenv
+).softclip(0.05, 0.25) * 10.db * cenv
 
 denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 156, sustain_level: 1, release_time: 20, rate: 48000)
 denv.trigger(1, auto_release: true)
@@ -40,9 +45,25 @@ drums = (hat + kick) * drumenv
 
 graph = ((drums + ab + c + d) * -6.db).softclip(0.25, 0.99)
 
-x, y = graph.tee
-flanger = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.at(0.001..0.008))
+if ARGV.include?('--bench')
+  raise 'TODO'
+else
+  m, s = graph.for(180).tee
 
-final = flanger.real.softclip(0.5, 0.99).for(180)
+  m1, m2 = m.real.tee
+  s1, s2 = s.imag.tee
 
-MB::Sound.play final.with_buffer(800)
+  l = m1 + -6.db * s1
+  r = m2 - -6.db * s2
+
+  final_l = l.tee.yield_self { |(x, y)|
+    flanger = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.at(0.001..0.008))
+    flanger.softclip(0.5, 0.99).with_buffer(800)
+  }
+  final_r = r.tee.yield_self { |(x, y)|
+    flanger = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.with_phase(Math::PI).at(0.001..0.008))
+    flanger.softclip(0.5, 0.99).with_buffer(800)
+  }
+
+  MB::Sound.play [final_l, final_r]
+end

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -8,9 +8,9 @@ require 'mb-sound'
 
 a = 100.hz.complex_square.forever.at(-6.db).filter(1500.hz.lowpass(quality: 0.5))
 b = 150.hz.ramp.forever.at(-7.db).filter(2600.hz.lowpass(quality: 0.5))
-c = 266.66667.hz.triangle.forever.at(-8.db).softclip(0.05, 0.5).filter(900.hz.lowpass1p) *
+c = 266.66667.hz.triangle.forever.at(-5.db).softclip(0.05, 0.5).filter(900.hz.lowpass1p) *
   0.1.hz.lfo.at(0..1) +
-  250.hz.complex_triangle.forever.at(-6.db).softclip(0.05, 0.5).filter(900.hz.lowpass1p) *
+  250.hz.complex_triangle.forever.at(-4.db).softclip(0.05, 0.5).filter(900.hz.lowpass1p) *
   0.1.hz.lfo.at(0..1).with_phase(Math::PI)
 
 denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 60, sustain_level: 1, release_time: 60, rate: 48000)
@@ -21,8 +21,12 @@ d = (
   4.hz.ramp.lfo.at(0..-30).db.filter(50.hz.lowpass)
 ).softclip(0.005, 0.25) * 10.db * denv
 
-#abcenv = MB::Sound::ADSREnvelope.new(attack_time: 30, decay_time: 60, sustain_level: 0.125, release_time: 30)
+abcenv = MB::Sound::ADSREnvelope.new(attack_time: 60, decay_time: 10, sustain_level: 0.125, release_time: 50, rate: 48000)
+abcenv.trigger(1, auto_release: true)
 
-graph = ((a + b + c) * 1.hz.ramp.lfo.at(2..0.1).filter(30.hz.lowpass) * 0.0001.hz.triangle.lfo.at(0..1).with_phase(-Math::PI/2) + d).softclip(0.25, 0.99)
+hat = 10000.hz.noise.filter(9000.hz.highpass).filter(15000.hz.lowpass) * 8.hz.ramp.lfo.at(0..-25).filter(100.hz.lowpass).db
+kick = 50.hz.at(-3.db).fm(2.hz.ramp.at(90.to_db..-60).db.filter(100.hz.lowpass)) * 2.hz.ramp.at(0..-30).db.filter(100.hz.lowpass)
+
+graph = (kick + hat + (a + b + c) * 1.hz.ramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abcenv + d).softclip(0.25, 0.99)
 
 MB::Sound.play graph.real.for(180)

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -9,10 +9,10 @@ require 'mb-sound'
 abenv = MB::Sound::ADSREnvelope.new(attack_time: 60, decay_time: 30, sustain_level: 0.125, release_time: 90, rate: 48000)
 abenv.trigger(1, auto_release: true)
 
-a = 100.hz.complex_square.forever.at(-10.db).filter(1500.hz.lowpass(quality: 0.5))
-b = 150.hz.ramp.forever.at(-12.db).filter(2600.hz.lowpass(quality: 0.5))
+a = 100.hz.complex_square.forever.at(-13.db).filter(1500.hz.lowpass(quality: 0.5))
+b = 150.hz.ramp.forever.at(-15.db).filter(2600.hz.lowpass(quality: 0.5))
 
-ab = (a + b) * 1.hz.ramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abenv
+ab = (a + b) * 1.hz.drumramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abenv
 
 cenv = MB::Sound::ADSREnvelope.new(attack_time: 90, decay_time: 60, sustain_level: 1, release_time: 30, rate: 48000)
 cenv.trigger(1, auto_release: true)
@@ -20,30 +20,29 @@ cenv.trigger(1, auto_release: true)
 c = (
   266.66667.hz.triangle.forever.at(-4.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1) +
   250.hz.complex_triangle.forever.at(-3.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1).with_phase(Math::PI)
-).softclip(0.05, 0.15) * 6.db * cenv
+).softclip(0.05, 0.25) * 15.db * cenv
 
 denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 156, sustain_level: 1, release_time: 20, rate: 48000)
 denv.trigger(1, auto_release: true)
 
 d = (
   50.hz.triangle.at(-3.db).forever.filter(150.hz.lowpass1p) *
-  4.hz.ramp.lfo.at(0..-30).db.filter(50.hz.lowpass)
+  4.hz.drumramp.lfo.at(0..-30).db.filter(50.hz.lowpass)
 ).softclip(0.005, 0.25) * 10.db * denv
 
 drumenv = MB::Sound::ADSREnvelope.new(attack_time: 10, decay_time: 160, sustain_level: 1, release_time: 10, rate: 48000)
 drumenv.trigger(1, auto_release: true)
 
-# FIXME: drum and bass hits don't seem to happen in time; figure out LFO-as-repeating-envelope phasing
-
-hat = 10000.hz.noise.filter(9000.hz.highpass).filter(15000.hz.lowpass) * 8.hz.ramp.lfo.at(-4..-25).filter(100.hz.lowpass).db
-kick = 50.hz.at(-3.db).fm(2.hz.ramp.at(90.to_db..-60).db.filter(100.hz.lowpass)) * 2.hz.ramp.at(0..-30).db.filter(100.hz.lowpass)
+hat = 10000.hz.noise.filter(9000.hz.highpass).filter(15000.hz.lowpass) * 8.hz.drumramp.lfo.at(-4..-25).filter(100.hz.lowpass).db
+kick = 50.hz.at(-3.db).fm(2.hz.drumramp.at(90.to_db..-60).db.filter(100.hz.lowpass)) * 2.hz.drumramp.at(0..-30).db.filter(100.hz.lowpass)
 
 drums = (hat + kick) * drumenv
 
 graph = ((drums + ab + c + d) * -6.db).softclip(0.25, 0.99)
 
 x, y = graph.tee
+flanger = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.at(0.001..0.008))
 
-effect = -4.db * x - -5.db * y.delay(seconds: 0.1.hz.triangle.lfo.at(0.001..0.008))
+final = flanger.real.softclip(0.5, 0.99).for(180)
 
-MB::Sound.play effect.real.softclip(0.5, 0.99).for(180).with_buffer(800)
+MB::Sound.play final.with_buffer(800)

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+
+require 'benchmark'
+
+require 'mb-sound'
+
+a = 100.hz.complex_square.forever.at(-6.db).filter(1500.hz.lowpass(quality: 0.5))
+b = 150.hz.ramp.forever.at(-7.db).filter(2600.hz.lowpass(quality: 0.5))
+c = 266.66667.hz.triangle.forever.at(-8.db).softclip(0.05, 0.5).filter(900.hz.lowpass1p) *
+  0.1.hz.lfo.at(0..1) +
+  250.hz.complex_triangle.forever.at(-6.db).softclip(0.05, 0.5).filter(900.hz.lowpass1p) *
+  0.1.hz.lfo.at(0..1).with_phase(Math::PI)
+
+denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 60, sustain_level: 1, release_time: 60, rate: 48000)
+denv.trigger(1, auto_release: true)
+
+d = (
+  50.hz.triangle.at(-3.db).forever.filter(150.hz.lowpass1p) *
+  4.hz.ramp.lfo.at(0..-30).db.filter(50.hz.lowpass)
+).softclip(0.005, 0.25) * 10.db * denv
+
+#abcenv = MB::Sound::ADSREnvelope.new(attack_time: 30, decay_time: 60, sustain_level: 0.125, release_time: 30)
+
+graph = ((a + b + c) * 1.hz.ramp.lfo.at(2..0.1).filter(30.hz.lowpass) * 0.0001.hz.triangle.lfo.at(0..1).with_phase(-Math::PI/2) + d).softclip(0.25, 0.99)
+
+MB::Sound.play graph.real.for(180)

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -18,7 +18,7 @@ abenv = MB::Sound::ADSREnvelope.new(attack_time: 60, decay_time: 30, sustain_lev
 a = 100.hz.complex_square.forever.at(-13.db).filter(1500.hz.lowpass(quality: 0.5))
 b = 150.hz.ramp.forever.at(-15.db).filter(2600.hz.lowpass(quality: 0.5))
 
-ab = (a + b).softclip(0.05, 0.2) * 1.hz.drumramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abenv
+ab = (a + b).softclip(0.05, 0.2) * 3.db * 1.hz.drumramp.lfo.at(2..0.1).filter(30.hz.lowpass) * abenv
 
 cenv = MB::Sound::ADSREnvelope.new(attack_time: 90, decay_time: 60, sustain_level: 1, release_time: 30, rate: 48000)
 
@@ -27,14 +27,14 @@ c = (
   250.hz.complex_triangle.forever.at(-3.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1).with_phase(Math::PI)
 ).softclip(0.05, 0.25) * 10.db * cenv
 
-denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 156, sustain_level: 1, release_time: 20, rate: 48000)
+denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 156, sustain_level: 1, release_time: 10, rate: 48000)
 
 d = (
   50.hz.triangle.at(-3.db).forever.filter(150.hz.lowpass1p) *
   4.hz.drumramp.lfo.at(0..-30).db.filter(50.hz.lowpass)
 ).softclip(0.005, 0.25) * 10.db * denv
 
-drumenv = MB::Sound::ADSREnvelope.new(attack_time: 10, decay_time: 160, sustain_level: 1, release_time: 10, rate: 48000)
+drumenv = MB::Sound::ADSREnvelope.new(attack_time: 10, decay_time: 160, sustain_level: 1, release_time: 20, rate: 48000)
 
 hat = 10000.hz.noise.filter(9000.hz.highpass).filter(15000.hz.lowpass) * 8.hz.drumramp.lfo.at(-4..-25).filter(100.hz.lowpass).db
 kick = 50.hz.at(-3.db).fm(2.hz.drumramp.at(90.to_db..-60).db.filter(100.hz.lowpass)) * 2.hz.drumramp.at(0..-30).db.filter(100.hz.lowpass)

--- a/bin/node_graph_benchmark.rb
+++ b/bin/node_graph_benchmark.rb
@@ -31,14 +31,14 @@ c = (
   250.hz.complex_triangle.forever.at(-3.db).softclip(0.05, 0.5).filter(1900.hz.lowpass1p) * 0.1.hz.lfo.at(0..1).with_phase(Math::PI)
 ).softclip(0.05, 0.25) * 10.db * cenv
 
-denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 156, sustain_level: 1, release_time: 10, rate: 48000)
+denv = MB::Sound::ADSREnvelope.new(attack_time: 4, decay_time: 170, sustain_level: 1, release_time: 6, rate: 48000)
 
 d = (
   50.hz.triangle.at(-3.db).forever.filter(150.hz.lowpass1p) *
   4.hz.drumramp.lfo.at(0..-30).db.filter(50.hz.lowpass)
 ).softclip(0.005, 0.25) * 10.db * denv
 
-drumenv = MB::Sound::ADSREnvelope.new(attack_time: 10, decay_time: 160, sustain_level: 1, release_time: 20, rate: 48000)
+drumenv = MB::Sound::ADSREnvelope.new(attack_time: 10, decay_time: 150, sustain_level: 1, release_time: 20, rate: 48000)
 
 hat = 10000.hz.noise.filter(9000.hz.highpass).filter(15000.hz.lowpass) * 8.hz.drumramp.lfo.at(-4..-25).filter(100.hz.lowpass).db
 kick = 50.hz.at(-3.db).fm(2.hz.drumramp.at(90.to_db..-60).db.filter(100.hz.lowpass)) * 2.hz.drumramp.at(0..-30).db.filter(100.hz.lowpass)

--- a/lib/mb/sound/adsr_envelope.rb
+++ b/lib/mb/sound/adsr_envelope.rb
@@ -350,7 +350,11 @@ module MB
       def advance(samples)
         @frame += samples
         @time = @frame / @rate.to_f
-        release if @auto_release && @on && @time >= @auto_release
+
+        release_time = @attack_time + @decay_time if @auto_release == true
+        release_time ||= @auto_release
+
+        release if @auto_release && @on && @time >= release_time
       end
     end
   end

--- a/lib/mb/sound/graph_node.rb
+++ b/lib/mb/sound/graph_node.rb
@@ -567,9 +567,6 @@ module MB
 
       # Sets all Tones in the graph to continue playing forever.
       def for(duration, recursive: true)
-        raise 'Recursion too deep' if caller_locations.length > 60
-        puts "#{' ' * caller_locations.length} GraphNode#for(#{duration}, recursive: #{recursive})" # XXX
-
         if recursive
           graph.each do |n|
             next if n == self

--- a/lib/mb/sound/graph_node.rb
+++ b/lib/mb/sound/graph_node.rb
@@ -565,6 +565,21 @@ module MB
         digraph
       end
 
+      # Sets all Tones in the graph to continue playing forever.
+      def for(duration, recursive: true)
+        raise 'Recursion too deep' if caller_locations.length > 60
+        puts "#{' ' * caller_locations.length} GraphNode#for(#{duration}, recursive: #{recursive})" # XXX
+
+        if recursive
+          graph.each do |n|
+            next if n == self
+            n.for(duration, recursive: false) if n.respond_to?(:for)
+          end
+        end
+
+        self
+      end
+
       # Sets all Tones in the graph (or anything else with a #forever method
       # that takes a :recursive parameter) to continue playing forever.
       def forever(recursive: true)

--- a/lib/mb/sound/graph_node/complex_node.rb
+++ b/lib/mb/sound/graph_node/complex_node.rb
@@ -48,7 +48,7 @@ module MB
             else
               raise "BUG: Unsupported mode #{@mode}"
             end
-          else
+          elsif data.is_a?(Numo::NArray)
             case @mode
             when :real
               data
@@ -69,6 +69,12 @@ module MB
             else
               raise "BUG: Unsupported mode #{@mode}"
             end
+
+          elsif data.nil?
+            nil
+
+          else
+            raise "Unsupported datatype: #{data.class}"
           end
         end
       end

--- a/lib/mb/sound/graph_node/constant.rb
+++ b/lib/mb/sound/graph_node/constant.rb
@@ -85,12 +85,13 @@ module MB
           [@constant]
         end
 
-        # Sets the duration for which this constant will run, or nil to run
-        # forever.
+        # Sets the duration for which this constant will run *from now*, or nil
+        # to run forever.
         def for(duration_seconds, recursive: true)
           puts "#{' ' * caller_locations.length} Constant#for(#{duration_seconds}, recursive: #{recursive})" # XXX
 
           super(duration_seconds, recursive: recursive)
+          @elapsed_samples = 0
           @duration_samples = duration_seconds && duration_seconds.to_f * @rate
           self
         end

--- a/lib/mb/sound/graph_node/constant.rb
+++ b/lib/mb/sound/graph_node/constant.rb
@@ -90,7 +90,7 @@ module MB
         def for(duration_seconds, recursive: true)
           puts "#{' ' * caller_locations.length} Constant#for(#{duration_seconds}, recursive: #{recursive})" # XXX
 
-          super(recursive: recursive)
+          super(duration_seconds, recursive: recursive)
           @duration_samples = duration_seconds && duration_seconds.to_f * @rate
           self
         end

--- a/lib/mb/sound/graph_node/constant.rb
+++ b/lib/mb/sound/graph_node/constant.rb
@@ -87,7 +87,10 @@ module MB
 
         # Sets the duration for which this constant will run, or nil to run
         # forever.
-        def for(duration_seconds)
+        def for(duration_seconds, recursive: true)
+          puts "#{' ' * caller_locations.length} Constant#for(#{duration_seconds}, recursive: #{recursive})" # XXX
+
+          super(recursive: recursive)
           @duration_samples = duration_seconds && duration_seconds.to_f * @rate
           self
         end

--- a/lib/mb/sound/graph_node/constant.rb
+++ b/lib/mb/sound/graph_node/constant.rb
@@ -88,8 +88,6 @@ module MB
         # Sets the duration for which this constant will run *from now*, or nil
         # to run forever.
         def for(duration_seconds, recursive: true)
-          puts "#{' ' * caller_locations.length} Constant#for(#{duration_seconds}, recursive: #{recursive})" # XXX
-
           super(duration_seconds, recursive: recursive)
           @elapsed_samples = 0
           @duration_samples = duration_seconds && duration_seconds.to_f * @rate

--- a/lib/mb/sound/graph_node/tee.rb
+++ b/lib/mb/sound/graph_node/tee.rb
@@ -48,6 +48,12 @@ module MB
           def to_s
             "Branch #{@index + 1} of #{@tee.branches.count}#{graph_node_name && " (#{graph_node_name})"}"
           end
+
+          # Resets the internal done flag to allow this tee to flow data again.
+          def for(duration, recursive: true)
+            super(duration, recursive: recursive)
+            @tee.reset
+          end
         end
 
         # The source node feeding into this Tee, in an array (see
@@ -103,6 +109,12 @@ module MB
 
         rescue MB::Sound::CircularBuffer::BufferOverflow
           raise BranchBufferOverflow, "Read of #{branch} overflowed internal buffer.  Buffers of all branches: #{@readers.map(&:length)}"
+        end
+
+        # Clears the "done" flag that returns nil if upstreams return nil, in
+        # case the upstreams were restarted.
+        def reset
+          @done = false
         end
       end
     end

--- a/lib/mb/sound/playback_methods.rb
+++ b/lib/mb/sound/playback_methods.rb
@@ -14,7 +14,7 @@ module MB
       # If the PLOT environment variable is set to '0', then plotting defaults
       # to false.  Otherwise, plotting defaults to true.
       def play(file_tone_data, rate: 48000, gain: 1.0, plot: nil, graphical: false, spectrum: false, device: nil)
-        header = MB::U.wrap("\e[H\e[J\e[36mPlaying\e[0m #{MB::U.highlight(file_tone_data)}".lines.map(&:strip).join(' ') + "\n\n")
+        header = MB::U.wrap("\e[H\e[J\e[36mPlaying\e[0m #{playback_info(file_tone_data)}".lines.map(&:strip).join(' ') + "\n\n")
         puts header
 
         plot = false if ENV['PLOT'] == '0' && plot.nil?
@@ -128,6 +128,21 @@ module MB
 
       ensure
         input&.close
+      end
+
+      # Returns a String with info to display when playing the given
+      # +file_tone_data+.
+      def playback_info(file_tone_data)
+        case file_tone_data
+        when Array
+          file_tone_data.map { |ftd| playback_info(ftd) }
+
+        when GraphNode
+          file_tone_data.graph.select { |n| n.is_a?(MB::Sound::GraphNode) }.map { |n| n.graph_node_name || n.class.name }.join(', ')
+
+        else
+          MB::U.highlight(file_tone_data)
+        end
       end
     end
   end

--- a/lib/mb/sound/tone.rb
+++ b/lib/mb/sound/tone.rb
@@ -296,7 +296,8 @@ module MB
         self
       end
 
-      # Sets the duration to the given number of seconds.
+      # Sets the duration to the given number of seconds, starting from now (in
+      # sample time).
       def for(duration, recursive: true)
         puts "#{' ' * caller_locations.length} Tone#for(#{duration}, recursive: #{recursive})" # XXX
 

--- a/lib/mb/sound/tone.rb
+++ b/lib/mb/sound/tone.rb
@@ -299,8 +299,6 @@ module MB
       # Sets the duration to the given number of seconds, starting from now (in
       # sample time).
       def for(duration, recursive: true)
-        puts "#{' ' * caller_locations.length} Tone#for(#{duration}, recursive: #{recursive})" # XXX
-
         super(duration, recursive: recursive)
 
         @duration_set = true

--- a/lib/mb/sound/tone.rb
+++ b/lib/mb/sound/tone.rb
@@ -203,6 +203,16 @@ module MB
         @wave_type = :ramp
         self
       end
+      alias saw ramp
+      alias sawtooth ramp
+
+      # Changes the waveform type to ramp, with phase set so the oscillator
+      # starts at the bottom instead of the middle of its ramp.  This allows
+      # using #drumramp oscillators to play beats in time with each other.
+      def drumramp
+        ramp.with_phase(-Math::PI)
+      end
+      alias envramp drumramp
 
       # Changes the waveform type to inverse Gaussian.  The histogram of this
       # waveform shows a truncated, roughly Gaussian distribution.  The peaks

--- a/lib/mb/sound/tone.rb
+++ b/lib/mb/sound/tone.rb
@@ -287,9 +287,14 @@ module MB
       end
 
       # Sets the duration to the given number of seconds.
-      def for(duration)
+      def for(duration, recursive: true)
+        puts "#{' ' * caller_locations.length} Tone#for(#{duration}, recursive: #{recursive})" # XXX
+
+        super(duration, recursive: recursive)
+
         @duration_set = true
         @duration = duration&.to_f
+
         self
       end
 

--- a/spec/bin/node_graph_benchmark_spec.rb
+++ b/spec/bin/node_graph_benchmark_spec.rb
@@ -1,0 +1,18 @@
+require 'fileutils'
+require 'shellwords'
+
+RSpec.describe('bin/node_graph_benchmark.rb') do
+  let(:outfile) { 'tmp/node_graph_output.flac' }
+
+  it 'can save the song to a file' do
+    FileUtils.mkdir_p(File.dirname(outfile))
+
+    output = `LOOP_COUNT=60 bin/node_graph_benchmark.rb #{outfile.shellescape} --overwrite`
+    expect($?).to be_success
+
+    expect(output).to include(outfile)
+
+    info = MB::Sound::FFMPEGInput.parse_info(outfile)
+    expect(info[:streams][0][:duration_ts]).to eq(48000)
+  end
+end

--- a/spec/bin/sound_spec.rb
+++ b/spec/bin/sound_spec.rb
@@ -1,8 +1,9 @@
-RSpec.describe('bin/sound.rb/', :aggregate_failures) do
+RSpec.describe('bin/sound.rb', :aggregate_failures) do
   it 'can start up and plot a sine wave' do
     raw_text = `printf "plot 123.hz\nexit\n" | bin/sound.rb`
     result = $?
     output = MB::U.remove_ansi(raw_text)
+    expect(result).to be_success
 
     expect(output).to include('Welcome to the'), 'shows the welcome text'
     expect(output).to include('sound.rb MB::Sound'), 'displays the right prompt'

--- a/spec/lib/mb/sound/graph_node/complex_node_spec.rb
+++ b/spec/lib/mb/sound/graph_node/complex_node_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe(MB::Sound::GraphNode::ComplexNode, :aggregate_failures) do
         end
       end
     end
+
+    pending 'returns nil for nil input'
   end
 
   describe '#sources' do

--- a/spec/lib/mb/sound/graph_node/constant_spec.rb
+++ b/spec/lib/mb/sound/graph_node/constant_spec.rb
@@ -54,4 +54,9 @@ RSpec.describe(MB::Sound::GraphNode::Constant) do
       expect(c.sample(1)).to eq(nil)
     end
   end
+
+  descirbe '#for' do
+    pending 'resets the elapsed timer'
+    pending 'limits the duration generated'
+  end
 end

--- a/spec/lib/mb/sound/graph_node/constant_spec.rb
+++ b/spec/lib/mb/sound/graph_node/constant_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe(MB::Sound::GraphNode::Constant) do
     end
   end
 
-  descirbe '#for' do
+  describe '#for' do
     pending 'resets the elapsed timer'
     pending 'limits the duration generated'
   end

--- a/spec/lib/mb/sound/graph_node/tee_spec.rb
+++ b/spec/lib/mb/sound/graph_node/tee_spec.rb
@@ -1,4 +1,7 @@
 RSpec.describe(MB::Sound::GraphNode::Tee) do
+  pending '#reset'
+  pending '::Branch#for'
+
   it 'can be created' do
     a, b = 123.hz.tee
     expect(a).to be_a(MB::Sound::GraphNode::Tee::Branch)

--- a/spec/lib/mb/sound/graph_node_spec.rb
+++ b/spec/lib/mb/sound/graph_node_spec.rb
@@ -368,4 +368,8 @@ RSpec.describe(MB::Sound::GraphNode) do
       expect(b).to eq(nil)
     end
   end
+
+  pending '#forever'
+
+  pending '#for'
 end

--- a/spec/lib/mb/sound/tone_spec.rb
+++ b/spec/lib/mb/sound/tone_spec.rb
@@ -219,6 +219,10 @@ RSpec.describe MB::Sound::Tone do
   pending '#fm'
   pending '#log_fm'
   pending '#pm'
+  describe '#for' do
+    pending 'limits duration'
+    pending 'resets elapsed timer'
+  end
 
   describe '#oscillator' do
     it 'returns an Oscillator with the same frequency and range' do


### PR DESCRIPTION
This is a benchmark script to run a fairly representative synthesis task that hits filters, oscillators, and delays in an audio node graph.  I also fixed minor issues discovered during development, and tweaked some of the nodes' code, like `ADSREnvelope`, to allow restarting a graph after it has finished.

The goal was to detect whether Ruby has been getting slower or faster over time _for this particular workload_, and also to compare a Ruby-heavy workload (a small buffer size) with a C-heavy workload (a large buffer size).

The results, which surprised me, show 3.0 as the fastest version of Ruby without JIT (just-in-time compilation), and 3.3 as the fastest version with JIT.

The benchmark also generates a simple 180-second song, which I've uploaded to Soundcloud: https://soundcloud.com/n2a-1/mb-sound-benchmark-song-2025.

# Benchmark results

Buffer size | Real time | Description
-- | -- | --
100 | 40.75 | 3.4 (binary) 100
100 | 39.90 | 3.4 (source) 100
100 | 37.87 | 3.3 100
100 | 37.53 | 2.7 100
100 | 35.03 | 3.2 100
100 | 34.91 | 3.1 100
100 | 33.48 | 3.0 100
100 | 33.45 | 2.7 jit 100
100 | 29.52 | 3.4 (binary) jit 100
100 | 29.16 | 3.0 jit 100
100 | 28.40 | 3.4 (source) jit 100
100 | 26.93 | 3.2 jit 100
100 | 26.73 | 3.1 jit 100
100 | 25.41 | 3.3 jit 100
800 | 21.88 | 3.4 (binary) 800
800 | 21.12 | 2.7 800
800 | 20.93 | 3.4 (source) 800
800 | 20.37 | 3.3 800
800 | 18.70 | 3.1 800
800 | 18.50 | 3.2 800
800 | 18.25 | 2.7 jit 800
800 | 17.50 | 3.0 800
800 | 16.14 | 3.4 (binary) jit 800
800 | 15.03 | 3.4 (source) jit 800
800 | 14.39 | 3.0 jit 800
800 | 14.12 | 3.1 jit 800
800 | 14.03 | 3.2 jit 800
800 | 13.71 | 3.3 jit 800
4000 | 19.51 | 3.4 (binary) 4000
4000 | 19.22 | 2.7 4000
4000 | 18.76 | 3.4 (source) 4000
4000 | 18.20 | 3.3 4000
4000 | 16.73 | 3.1 4000
4000 | 16.49 | 3.2 4000
4000 | 16.47 | 2.7 jit 4000
4000 | 15.49 | 3.0 4000
4000 | 14.51 | 3.4 (binary) jit 4000
4000 | 13.46 | 3.4 (source) jit 4000
4000 | 12.63 | 3.0 jit 4000
4000 | 12.51 | 3.1 jit 4000
4000 | 12.49 | 3.2 jit 4000
4000 | 12.32 | 3.3 jit 4000

