### PR TITLE
Fix resampling of nodes that produce Numo::DFloat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-sound (0.9.0.usegit)
+    mb-sound (0.9.0.1.usegit)
       cmath (~> 1.0.0)
       csv (~> 3.3, >= 3.3.3)
       mb-math (>= 0.2.8.usegit)

--- a/ext/mb/sound/fast_resample/fast_resample.c
+++ b/ext/mb/sound/fast_resample/fast_resample.c
@@ -159,6 +159,11 @@ static long read_callback(void *data, float **audio)
 		return 0;
 	}
 
+	VALUE buf_class = rb_class_of(buf);
+	if (buf_class != numo_cSFloat) {
+		rb_raise(rb_eTypeError, "Data from read callback is %"PRIsVALUE", not Numo::SFloat", buf_class);
+	}
+
 	*audio = (float *)(nary_get_pointer_for_read(buf) + nary_get_offset(buf));
 
 	narray_t *na;

--- a/lib/mb/sound/version.rb
+++ b/lib/mb/sound/version.rb
@@ -1,5 +1,5 @@
 module MB
   module Sound
-    VERSION = "0.9.0.usegit"
+    VERSION = "0.9.0.1.usegit"
   end
 end

--- a/spec/ext/mb/sound/fast_resample_spec.rb
+++ b/spec/ext/mb/sound/fast_resample_spec.rb
@@ -104,6 +104,13 @@ RSpec.describe(MB::Sound::FastResample, :aggregate_failures) do
         expect(result.sum / result.length - 1).to be_between(-1e-2, 1e-2)
       end
 
+      it 'raises an error if given something other than Numo::SFloat' do
+        # TODO: Better way of changing the callback for tests
+        r_half.instance_variable_set(:@callback, ->(size) { Numo::DFloat.ones(size) })
+
+        expect { r_half.read(100) }.to raise_error(TypeError, /SFloat/)
+      end
+
       it 'can handle a subset view from the read block' do
         # TODO: Better way of changing the callback for tests
         r_double.instance_variable_set(:@callback, ->(size) { Numo::SFloat.zeros(size).concatenate(Numo::SFloat.ones(size))[0...size] })


### PR DESCRIPTION
Prior to this fix, nodes returning `Numo::DFloat` would generate random, glitchy output when resampled by libsamplerate, because the data was being interpreted as an array of float but was actually an array of double.