### PR TITLE
Switch to numo-narray-alt for in-repo development

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.2', '3.4']
+        ruby-version: ['3.2', '3.4']
     steps:
       - uses: actions/checkout@v3
       - name: Install Ruby

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@
 /spec/examples.txt
 .gdb_history
 /lib/**/*.so
+/lib/**/*.bundle
 .byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 gem 'readline', require: true
 
 gem 'numo-narray', github: 'mike-bourgeous/numo-narray-compat.git', branch: 'compat-9-2-x'
-gem 'numo-narray-alt', '~> 0.10.4', github: 'mike-bourgeous/numo-narray-alt-fork.git', branch: 'fix-double-macro-argument-reference'
 
 gem 'mb-math', github: 'mike-bourgeous/mb-math.git'
 gem 'mb-util', github: 'mike-bourgeous/mb-util.git'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gemspec
 gem 'readline', require: true
 
 gem 'numo-narray', github: 'mike-bourgeous/numo-narray-compat.git', branch: 'compat-9-2-x'
-gem 'numo-narray-alt', '~> 0.10.4'
+gem 'numo-narray-alt', '~> 0.10.4', github: 'mike-bourgeous/numo-narray-alt-fork.git', branch: 'fix-double-macro-argument-reference'
 
 gem 'mb-math', github: 'mike-bourgeous/mb-math.git'
 gem 'mb-util', github: 'mike-bourgeous/mb-util.git'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gemspec
 
 gem 'readline', require: true
 
+gem 'numo-narray', github: 'mike-bourgeous/numo-narray-compat.git', branch: 'compat-9-2-x'
+gem 'numo-narray-alt', '~> 0.10.4'
+
 gem 'mb-math', github: 'mike-bourgeous/mb-math.git'
 gem 'mb-util', github: 'mike-bourgeous/mb-util.git'
 gem 'mb-sound-jackffi', github: 'mike-bourgeous/mb-sound-jackffi.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,23 @@
 GIT
   remote: https://github.com/mike-bourgeous/mb-math.git
-  revision: 22516a59e75dc706d1584e2f20550568224e9283
+  revision: 48b9b692e7d60c9c67fff04aa574377c6322e826
   specs:
-    mb-math (0.4.7.usegit)
+    mb-math (0.5.0.usegit)
       bigdecimal (~> 3.1.8)
       cmath (~> 1.0.0)
       matrix (~> 0.4.2)
-      mb-util (>= 0.1.21.usegit)
-      numo-narray (~> 0.9.2.1)
-      numo-pocketfft (~> 0.4.1)
+      mb-util (>= 0.1.29.usegit)
+      numo-narray-alt (~> 0.10.5)
+      numo-pocketfft (~> 0.6.0)
       prime (~> 0.1.3)
 
 GIT
   remote: https://github.com/mike-bourgeous/mb-sound-jackffi.git
-  revision: 23ca5fd935a28fcde978c2c02270ede3e8d8d436
+  revision: 8809c434cde6e407c8afcc52e8e754f9be04031f
   specs:
-    mb-sound-jackffi (0.2.0.usegit)
+    mb-sound-jackffi (0.3.0.usegit)
       ffi (~> 1.13.0)
-      numo-narray (>= 0.9.1)
+      numo-narray-alt (~> 0.10.5)
 
 GIT
   remote: https://github.com/mike-bourgeous/mb-util.git
@@ -39,16 +39,17 @@ PATH
   remote: .
   specs:
     mb-sound (0.11.0.usegit)
+      builder (~> 3.2.4)
       cmath (~> 1.0.0)
       csv (~> 3.3, >= 3.3.3)
       logger (~> 1.7.0)
-      mb-math (>= 0.4.7.usegit)
-      mb-sound-jackffi (>= 0.2.0.usegit)
+      mb-math (>= 0.5.0.usegit)
+      mb-sound-jackffi (>= 0.3.0.usegit)
       mb-util (>= 0.1.29.usegit)
       midi-nibbler (~> 0.2.4)
       midilib (~> 4.0.0)
-      numo-narray (~> 0.9.2)
-      numo-pocketfft (~> 0.4.1)
+      numo-narray-alt (~> 0.10.5)
+      numo-pocketfft (~> 0.6.0)
       ostruct (~> 0.6.3)
       psych (~> 5.2.3)
 
@@ -59,15 +60,13 @@ GEM
     bigdecimal (3.1.9)
     builder (3.2.4)
     byebug (11.1.3)
-    cgi (0.5.1)
     cmath (1.0.0)
     coderay (1.1.3)
     csv (3.3.5)
     date (3.5.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    erb (4.0.4.1)
-      cgi (>= 0.3.3)
+    erb (6.0.4)
     ffi (1.13.1)
     forwardable (1.3.3)
     getoptlong (0.2.1)
@@ -84,8 +83,8 @@ GEM
       midi-message (~> 0.4, >= 0.4.4)
     midilib (4.0.2)
     numo-narray-alt (0.10.5)
-    numo-pocketfft (0.4.1)
-      numo-narray (>= 0.9.1)
+    numo-pocketfft (0.6.0)
+      numo-narray-alt (>= 0.9.9, < 0.11.0)
     ostruct (0.6.3)
     pp (0.6.3)
       prettyprint
@@ -139,7 +138,7 @@ GEM
     stringio (3.2.0)
     tsort (0.2.0)
     word_wrap (1.0.0)
-    yard (0.9.43)
+    yard (0.9.44)
 
 PLATFORMS
   x86_64-darwin-25
@@ -147,7 +146,6 @@ PLATFORMS
 
 DEPENDENCIES
   benchmark (~> 0.5.0)
-  builder (~> 3.2.4)
   bundler (= 2.4.22)
   forwardable (~> 1.3.3)
   getoptlong (~> 0.2.1)
@@ -157,7 +155,6 @@ DEPENDENCIES
   mb-sound-jackffi!
   mb-util!
   numo-narray!
-  numo-narray-alt (~> 0.10.5)
   pry (~> 0.14.0)
   pry-byebug (~> 3.10.0)
   pry-doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,19 +26,12 @@ GIT
     mb-util (0.1.29.usegit)
 
 GIT
-  remote: https://github.com/mike-bourgeous/numo-narray-alt-fork.git
-  revision: 22995a4b81ffb692fc27d7146f8037c7d7a65f3a
-  branch: fix-double-macro-argument-reference
-  specs:
-    numo-narray-alt (0.10.4)
-
-GIT
   remote: https://github.com/mike-bourgeous/numo-narray-compat.git
-  revision: 070b8fdc048666f7ac975955e1e9b2fa24bf78e9
+  revision: 4f98ebad51fd8aecc8e6b2d69e6b8e265f6b0fe8
   branch: compat-9-2-x
   specs:
     numo-narray (0.9.2.9999.pre.alt.pre.compat)
-      numo-narray-alt (>= 0.10)
+      numo-narray-alt (>= 0.10.5)
       rake (~> 13.0)
       rake-compiler (~> 1.1.1)
 
@@ -90,6 +83,7 @@ GEM
     midi-nibbler (0.2.4)
       midi-message (~> 0.4, >= 0.4.4)
     midilib (4.0.2)
+    numo-narray-alt (0.10.5)
     numo-pocketfft (0.4.1)
       numo-narray (>= 0.9.1)
     ostruct (0.6.3)
@@ -163,7 +157,7 @@ DEPENDENCIES
   mb-sound-jackffi!
   mb-util!
   numo-narray!
-  numo-narray-alt (~> 0.10.4)!
+  numo-narray-alt (~> 0.10.5)
   pry (~> 0.14.0)
   pry-byebug (~> 3.10.0)
   pry-doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,13 @@ GIT
     mb-util (0.1.29.usegit)
 
 GIT
+  remote: https://github.com/mike-bourgeous/numo-narray-alt-fork.git
+  revision: 22995a4b81ffb692fc27d7146f8037c7d7a65f3a
+  branch: fix-double-macro-argument-reference
+  specs:
+    numo-narray-alt (0.10.4)
+
+GIT
   remote: https://github.com/mike-bourgeous/numo-narray-compat.git
   revision: 070b8fdc048666f7ac975955e1e9b2fa24bf78e9
   branch: compat-9-2-x
@@ -83,7 +90,6 @@ GEM
     midi-nibbler (0.2.4)
       midi-message (~> 0.4, >= 0.4.4)
     midilib (4.0.2)
-    numo-narray-alt (0.10.4)
     numo-pocketfft (0.4.1)
       numo-narray (>= 0.9.1)
     ostruct (0.6.3)
@@ -143,6 +149,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-25
+  x86_64-linux
 
 DEPENDENCIES
   benchmark (~> 0.5.0)
@@ -156,7 +163,7 @@ DEPENDENCIES
   mb-sound-jackffi!
   mb-util!
   numo-narray!
-  numo-narray-alt (~> 0.10.4)
+  numo-narray-alt (~> 0.10.4)!
   pry (~> 0.14.0)
   pry-byebug (~> 3.10.0)
   pry-doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,17 +13,27 @@ GIT
 
 GIT
   remote: https://github.com/mike-bourgeous/mb-sound-jackffi.git
-  revision: 2e6a2a9e698996fae3d9404a1ff76ac92266d7d2
+  revision: 23ca5fd935a28fcde978c2c02270ede3e8d8d436
   specs:
     mb-sound-jackffi (0.2.0.usegit)
       ffi (~> 1.13.0)
-      numo-narray (~> 0.9.1)
+      numo-narray (>= 0.9.1)
 
 GIT
   remote: https://github.com/mike-bourgeous/mb-util.git
   revision: 705bde97bc29bbd031a06c02c6592ba9114a5947
   specs:
     mb-util (0.1.29.usegit)
+
+GIT
+  remote: https://github.com/mike-bourgeous/numo-narray-compat.git
+  revision: 070b8fdc048666f7ac975955e1e9b2fa24bf78e9
+  branch: compat-9-2-x
+  specs:
+    numo-narray (0.9.2.9999.pre.alt.pre.compat)
+      numo-narray-alt (>= 0.10)
+      rake (~> 13.0)
+      rake-compiler (~> 1.1.1)
 
 PATH
   remote: .
@@ -73,7 +83,7 @@ GEM
     midi-nibbler (0.2.4)
       midi-message (~> 0.4, >= 0.4.4)
     midilib (4.0.2)
-    numo-narray (0.9.2.1)
+    numo-narray-alt (0.10.4)
     numo-pocketfft (0.4.1)
       numo-narray (>= 0.9.1)
     ostruct (0.6.3)
@@ -132,7 +142,7 @@ GEM
     yard (0.9.43)
 
 PLATFORMS
-  x86_64-linux
+  x86_64-darwin-25
 
 DEPENDENCIES
   benchmark (~> 0.5.0)
@@ -145,6 +155,8 @@ DEPENDENCIES
   mb-sound!
   mb-sound-jackffi!
   mb-util!
+  numo-narray!
+  numo-narray-alt (~> 0.10.4)
   pry (~> 0.14.0)
   pry-byebug (~> 3.10.0)
   pry-doc

--- a/bin/benchmark_ruby_versions.rb
+++ b/bin/benchmark_ruby_versions.rb
@@ -31,7 +31,7 @@ end.parse!
 if ARGV.any?
   VERSION_LIST=ARGV
 else
-  VERSION_LIST=%w{2.7 3.0 3.1 3.2 3.3 3.4 4.0}
+  VERSION_LIST=%w{3.2 3.3 3.4 4.0}
 end
 
 def check_success(*msg)

--- a/ext/mb/fast_sound/extconf.rb
+++ b/ext/mb/fast_sound/extconf.rb
@@ -10,7 +10,9 @@ require 'numo/narray'
 # Documented here: https://stackoverflow.com/questions/45924206/ruby-native-extension-use-other-c-extension-gem/79952482#79952482
 na = Gem.loaded_specs['numo-narray']
 raise "Could not find the numo-narray Gem; try running with Bundler" if na.nil?
-raise 'Could not find narray.h' unless find_header('numo/narray.h', File.join(na.extension_dir, 'numo'))
+
+extdir = na.extension_dir
+raise "Could not find narray.h under #{extdir}" unless find_header('numo/narray.h', File.join(extdir, 'numo'))
 
 with_cflags("#{$CFLAGS} -O3 -ggdb3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE -D_ISOC99_SOURCE -D_GNU_SOURCE") do
   create_makefile('mb/fast_sound')

--- a/ext/mb/fast_sound/extconf.rb
+++ b/ext/mb/fast_sound/extconf.rb
@@ -6,10 +6,12 @@ require 'numo/narray'
 # Used numo-pocketfft as a reference for finding narray.h
 # https://github.com/yoshoku/numo-pocketfft/blob/1ab489b165d4cde06b6d3a443ed9bfbc8e5c69d0/ext/numo/pocketfft/extconf.rb
 # https://stackoverflow.com/questions/9322078/programmatically-determine-gems-path-using-bundler
+#
+# Documented here: https://stackoverflow.com/questions/45924206/ruby-native-extension-use-other-c-extension-gem/79952482#79952482
 na = Gem.loaded_specs['numo-narray']
 raise "Could not find the numo-narray Gem; try running with Bundler" if na.nil?
 raise 'Could not find narray.h' unless find_header('numo/narray.h', File.join(na.extension_dir, 'numo'))
 
-with_cflags("#{$CFLAGS} -O3 -ggdb3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE=700 -D_ISOC99_SOURCE -D_GNU_SOURCE") do
+with_cflags("#{$CFLAGS} -O3 -ggdb3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE -D_ISOC99_SOURCE -D_GNU_SOURCE") do
   create_makefile('mb/fast_sound')
 end

--- a/ext/mb/fast_sound/fast_sound.c
+++ b/ext/mb/fast_sound/fast_sound.c
@@ -1263,6 +1263,7 @@ static VALUE ruby_biquad_complex(VALUE self, VALUE b0, VALUE b1, VALUE b2, VALUE
 
 #define BIQUAD_LOOP(buf_type, coeff_type, conv_from_rb, conv_to_rb, filter_func) do { \
 	buf_type *data = (buf_type *)(nary_get_pointer_for_read_write(buf) + nary_get_offset(buf)); \
+	fprintf(stderr, "Biquad loop buf=" #buf_type " coeff=" #coeff_type "ptr=%p, offset=%zd\n", nary_get_pointer_for_read_write(buf), nary_get_offset(buf)); /* XXX */ \
 \
 	coeff_type x0 = 0; \
 	coeff_type x1 = conv_from_rb(rb_ary_entry(state, 1)); \
@@ -1280,6 +1281,9 @@ static VALUE ruby_biquad_complex(VALUE self, VALUE b0, VALUE b1, VALUE b2, VALUE
 	for (size_t i = 0; i < length; i++) { \
 		x0 = data[i]; \
 		y0 = filter_func(b0, b1, b2, a1, a2, x0, x1, x2, y1, y2); \
+		if (i < 30) { \
+			fprintf(stderr, "  bqloop iter %zu in=%f out=%f\n", i, creal(x0), creal(y0)); /* XXX */ \
+		} \
 		data[i] = y0; \
 		y2 = y1; \
 		y1 = y0; \
@@ -1325,7 +1329,8 @@ static VALUE ruby_biquad_narray(VALUE self, VALUE rb0, VALUE rb1, VALUE rb2, VAL
 		buf_type = CLASS_OF(buf);
 	}
 
-	// If that's still not a float or complex type, force conversion to float
+	// If that's still not a float or complex type (e.g. we had an Array of
+	// Integers), force conversion to float
 	buf_type = CLASS_OF(buf);
 	if (buf_type != numo_cDComplex && buf_type != numo_cSComplex && buf_type != numo_cSFloat && buf_type != numo_cDFloat) {
 		buf = rb_funcall(numo_cDFloat, rb_intern("cast"), 1, buf);
@@ -1348,12 +1353,16 @@ static VALUE ruby_biquad_narray(VALUE self, VALUE rb0, VALUE rb1, VALUE rb2, VAL
 	size_t length = RNARRAY_SHAPE(buf)[0];
 
 	if (buf_type == numo_cSFloat) {
+		puts("Biquad sfloat"); // XXX
 		BIQUAD_LOOP(float, double, NUM2DBL, DBL2NUM, biquad_filter);
 	} else if (buf_type == numo_cDFloat) {
+		puts("Biquad dfloat"); // XXX
 		BIQUAD_LOOP(double, double, NUM2DBL, DBL2NUM, biquad_filter);
 	} else if (buf_type == numo_cSComplex) {
+		puts("Biquad scomplex"); // XXX
 		BIQUAD_LOOP(float complex, double complex, num_to_complex, complex_to_num, biquad_complex);
 	} else if (buf_type == numo_cDComplex) {
+		puts("Biquad dcomplex"); // XXX
 		BIQUAD_LOOP(double complex, double complex, num_to_complex, complex_to_num, biquad_complex);
 	} else {
 		rb_raise(rb_eException, "BUG: Buffer was not SFloat, DFloat, SComplex, or DComplex");

--- a/ext/mb/fast_sound/fast_sound.c
+++ b/ext/mb/fast_sound/fast_sound.c
@@ -1263,7 +1263,6 @@ static VALUE ruby_biquad_complex(VALUE self, VALUE b0, VALUE b1, VALUE b2, VALUE
 
 #define BIQUAD_LOOP(buf_type, coeff_type, conv_from_rb, conv_to_rb, filter_func) do { \
 	buf_type *data = (buf_type *)(nary_get_pointer_for_read_write(buf) + nary_get_offset(buf)); \
-	fprintf(stderr, "Biquad loop buf=" #buf_type " coeff=" #coeff_type "ptr=%p, offset=%zd\n", nary_get_pointer_for_read_write(buf), nary_get_offset(buf)); /* XXX */ \
 \
 	coeff_type x0 = 0; \
 	coeff_type x1 = conv_from_rb(rb_ary_entry(state, 1)); \
@@ -1281,9 +1280,6 @@ static VALUE ruby_biquad_complex(VALUE self, VALUE b0, VALUE b1, VALUE b2, VALUE
 	for (size_t i = 0; i < length; i++) { \
 		x0 = data[i]; \
 		y0 = filter_func(b0, b1, b2, a1, a2, x0, x1, x2, y1, y2); \
-		if (i < 30) { \
-			fprintf(stderr, "  bqloop iter %zu in=%f out=%f\n", i, creal(x0), creal(y0)); /* XXX */ \
-		} \
 		data[i] = y0; \
 		y2 = y1; \
 		y1 = y0; \
@@ -1353,16 +1349,12 @@ static VALUE ruby_biquad_narray(VALUE self, VALUE rb0, VALUE rb1, VALUE rb2, VAL
 	size_t length = RNARRAY_SHAPE(buf)[0];
 
 	if (buf_type == numo_cSFloat) {
-		puts("Biquad sfloat"); // XXX
 		BIQUAD_LOOP(float, double, NUM2DBL, DBL2NUM, biquad_filter);
 	} else if (buf_type == numo_cDFloat) {
-		puts("Biquad dfloat"); // XXX
 		BIQUAD_LOOP(double, double, NUM2DBL, DBL2NUM, biquad_filter);
 	} else if (buf_type == numo_cSComplex) {
-		puts("Biquad scomplex"); // XXX
 		BIQUAD_LOOP(float complex, double complex, num_to_complex, complex_to_num, biquad_complex);
 	} else if (buf_type == numo_cDComplex) {
-		puts("Biquad dcomplex"); // XXX
 		BIQUAD_LOOP(double complex, double complex, num_to_complex, complex_to_num, biquad_complex);
 	} else {
 		rb_raise(rb_eException, "BUG: Buffer was not SFloat, DFloat, SComplex, or DComplex");

--- a/ext/mb/sound/fast_resample/extconf.rb
+++ b/ext/mb/sound/fast_resample/extconf.rb
@@ -13,6 +13,6 @@ raise 'Could not find narray.h' unless find_header('numo/narray.h', File.join(na
 # Find libsamplerate
 raise 'libsamplerate not found; please install libsamplerate0-dev' unless have_library("samplerate", "src_callback_new")
 
-with_cflags("#{$CFLAGS} -O3 -ggdb3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE=700 -D_ISOC99_SOURCE -D_GNU_SOURCE") do
+with_cflags("#{$CFLAGS} -O3 -ggdb3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE -D_ISOC99_SOURCE -D_GNU_SOURCE") do
   create_makefile('mb/sound/fast_resample')
 end

--- a/ext/mb/sound/fast_wavetable/extconf.rb
+++ b/ext/mb/sound/fast_wavetable/extconf.rb
@@ -10,6 +10,6 @@ na = Gem.loaded_specs['numo-narray']
 raise "Could not find the numo-narray Gem; try running with Bundler" if na.nil?
 raise 'Could not find narray.h' unless find_header('numo/narray.h', File.join(na.extension_dir, 'numo'))
 
-with_cflags("#{$CFLAGS} -O3 -ggdb3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE=700 -D_ISOC99_SOURCE -D_GNU_SOURCE") do
+with_cflags("#{$CFLAGS} -O3 -ggdb3 -Wall -Wextra -Werror -Wno-unused-parameter #{ENV['EXTRACFLAGS']} -std=c99 -D_XOPEN_SOURCE -D_ISOC99_SOURCE -D_GNU_SOURCE") do
   create_makefile('mb/sound/fast_wavetable')
 end

--- a/lib/mb/sound/filter/biquad.rb
+++ b/lib/mb/sound/filter/biquad.rb
@@ -197,10 +197,15 @@ module MB
 
         # Ruby outer loop, C math (slightly faster than pure Ruby)
         def process_ruby_c(samples)
+          puts "Ruby/C biquad loop: #{samples.class}"
+
           if samples.is_a?(Numo::DComplex) || samples.is_a?(Numo::SComplex) || samples[0].is_a?(Complex)
             # Direct Form I
-            samples.map do |x0|
+            idx = 0
+            samples.not_inplace!.map do |x0|
+              puts "   #{x0}" # XXX
               out = MB::FastSound.biquad_complex(@b0, @b1, @b2, @a1, @a2, x0, @x1, @x2, @y1, @y2)
+              puts "  ruby_c cplx bqloop iter=#{idx}/#{samples.length} in=#{x0} out=#{out}" #if idx < 100 # XXX remove idx
               @y2 = @y1
               @y1 = out
               @x2 = @x1
@@ -208,8 +213,12 @@ module MB
               out
             end
           else
-            samples.map do |x0|
+            idx = 0
+            samples.not_inplace!.map do |x0|
+              puts "   #{x0}" # XXX
               out = MB::FastSound.biquad(@b0, @b1, @b2, @a1, @a2, x0, @x1, @x2, @y1, @y2)
+              puts "  ruby_c bqloop iter=#{idx}/#{samples.length} in=#{x0} out=#{out}" #if idx < 100 # XXX remove idx
+              idx += 1 # XXX
               @y2 = @y1
               @y1 = out
               @x2 = @x1
@@ -221,9 +230,14 @@ module MB
 
         # Ruby outer loop, Ruby math
         def process_ruby(samples)
+          puts "Pure Ruby biquad loop: #{samples.class}" # XXX
+
           # Direct Form I
-          samples.map do |x0|
+          idx = 0
+          samples.not_inplace!.map do |x0|
             out = @b0 * x0 + @b1 * @x1 + @b2 * @x2 - @a1 * @y1 - @a2 * @y2
+            puts "  ruby_orig bqloop iter=#{idx}/#{samples.length} in=#{x0} out=#{out}" if idx < 100 # XXX remove idx
+            idx += 1 # XXX
             out = 0 if out.abs < 1e-18 && @y2.abs < 1e-18 && @y1.abs < 1e-18
             @y2 = @y1
             @y1 = out

--- a/lib/mb/sound/filter/biquad.rb
+++ b/lib/mb/sound/filter/biquad.rb
@@ -197,15 +197,10 @@ module MB
 
         # Ruby outer loop, C math (slightly faster than pure Ruby)
         def process_ruby_c(samples)
-          puts "Ruby/C biquad loop: #{samples.class}"
-
           if samples.is_a?(Numo::DComplex) || samples.is_a?(Numo::SComplex) || samples[0].is_a?(Complex)
             # Direct Form I
-            idx = 0
-            samples.not_inplace!.map do |x0|
-              puts "   #{x0}" # XXX
+            samples.map do |x0|
               out = MB::FastSound.biquad_complex(@b0, @b1, @b2, @a1, @a2, x0, @x1, @x2, @y1, @y2)
-              puts "  ruby_c cplx bqloop iter=#{idx}/#{samples.length} in=#{x0} out=#{out}" #if idx < 100 # XXX remove idx
               @y2 = @y1
               @y1 = out
               @x2 = @x1
@@ -213,12 +208,8 @@ module MB
               out
             end
           else
-            idx = 0
-            samples.not_inplace!.map do |x0|
-              puts "   #{x0}" # XXX
+            samples.map do |x0|
               out = MB::FastSound.biquad(@b0, @b1, @b2, @a1, @a2, x0, @x1, @x2, @y1, @y2)
-              puts "  ruby_c bqloop iter=#{idx}/#{samples.length} in=#{x0} out=#{out}" #if idx < 100 # XXX remove idx
-              idx += 1 # XXX
               @y2 = @y1
               @y1 = out
               @x2 = @x1
@@ -230,14 +221,9 @@ module MB
 
         # Ruby outer loop, Ruby math
         def process_ruby(samples)
-          puts "Pure Ruby biquad loop: #{samples.class}" # XXX
-
           # Direct Form I
-          idx = 0
-          samples.not_inplace!.map do |x0|
+          samples.map do |x0|
             out = @b0 * x0 + @b1 * @x1 + @b2 * @x2 - @a1 * @y1 - @a2 * @y2
-            puts "  ruby_orig bqloop iter=#{idx}/#{samples.length} in=#{x0} out=#{out}" if idx < 100 # XXX remove idx
-            idx += 1 # XXX
             out = 0 if out.abs < 1e-18 && @y2.abs < 1e-18 && @y1.abs < 1e-18
             @y2 = @y1
             @y1 = out

--- a/lib/mb/sound/io_methods.rb
+++ b/lib/mb/sound/io_methods.rb
@@ -273,6 +273,7 @@ module MB
 
         return :null if device == 'null' || device == ':null' || device == :null
 
+        # TODO: Dedupe with detect_output
         case RUBY_PLATFORM
         when /linux/
           if `pgrep jackd`.strip.length > 0
@@ -285,6 +286,17 @@ module MB
             :alsa_pulse
           else
             :alsa
+          end
+
+        when /darwin/
+          if `pgrep jackd`.strip.length > 0
+            if defined?(JackFFI)
+              :jack_ffi
+            else
+              :jack
+            end
+          else
+            raise NotImplementedError, 'JackD is currently required on macOS'
           end
 
         else
@@ -380,6 +392,19 @@ module MB
             :alsa_pulse
           else
             :alsa
+          end
+
+        when /darwin/
+          # TODO: mac output is flaky, has glitches when plotting to terminal, and MIDI input crashes when RUBYOPT=--jit
+          # jackd -R -X coremidi -d coreaudio
+          if `pgrep jackd`.strip.length > 0
+            if defined?(JackFFI)
+              :jack_ffi
+            else
+              :jack
+            end
+          else
+            raise NotImplementedError, 'JackD is currently required on macOS'
           end
 
         else

--- a/mb-sound.gemspec
+++ b/mb-sound.gemspec
@@ -35,22 +35,22 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'logger', '~> 1.7.0'
 
   spec.add_runtime_dependency 'cmath', '~> 1.0.0'
-  spec.add_runtime_dependency 'numo-narray', '~> 0.9.2'
-  spec.add_runtime_dependency 'numo-pocketfft', '~> 0.4.1'
+  spec.add_runtime_dependency 'numo-narray-alt', '~> 0.10.5'
+  spec.add_runtime_dependency 'numo-pocketfft', '~> 0.6.0'
 
   spec.add_runtime_dependency 'midi-nibbler', '~> 0.2.4'
-
   spec.add_runtime_dependency 'midilib', '~> 4.0.0'
 
-  spec.add_runtime_dependency 'mb-math', '>= 0.4.7.usegit'
+  spec.add_runtime_dependency 'mb-math', '>= 0.5.0.usegit'
   spec.add_runtime_dependency 'mb-util', '>= 0.1.29.usegit'
-  spec.add_runtime_dependency 'mb-sound-jackffi', '>= 0.2.0.usegit'
+  spec.add_runtime_dependency 'mb-sound-jackffi', '>= 0.3.0.usegit'
+
+  # For generating MIDI controller templates for ACID
+  spec.add_runtime_dependency 'builder', '~> 3.2.4'
 
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'bundler', '2.4.22'
-
-  # For generating MIDI controller templates for ACID
-  spec.add_development_dependency 'builder', '~> 3.2.4'
+  spec.add_development_dependency 'rake-compiler', '~> 1.1.1'
 
   # Interactive command line gems
   spec.add_development_dependency 'irb', '~> 1.16.0'
@@ -63,8 +63,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'benchmark', '~> 0.5.0'
-
-  spec.add_development_dependency 'rake-compiler', '~> 1.1.1'
 
   spec.add_development_dependency 'getoptlong', '~> 0.2.1'
   spec.add_development_dependency 'forwardable', '~> 1.3.3'

--- a/mb-sound.gemspec
+++ b/mb-sound.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
     to an educational video series about sound.
   }
   spec.homepage      = "https://github.com/mike-bourgeous/mb-sound"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.1")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mike-bourgeous/mb-sound"

--- a/mb-sound.gemspec
+++ b/mb-sound.gemspec
@@ -23,9 +23,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|sounds|tmp|coverage)/}) }
   end
-  spec.bindir        = "bin"
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.bindir        = "bin"
+  # TODO: decide what tools should be exposed when the gem is installed
+  #spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
   spec.extensions = ['ext/mb/fast_sound/extconf.rb', 'ext/mb/sound/fast_resample/extconf.rb']
 


### PR DESCRIPTION
It appears that work on https://github.com/ruby-numo/numo-narray has slowed or stalled lately, so switch to https://github.com/yoshoku/numo-narray-alt for more continuous updates.  This approach of using [numo-narray-compat](https://github.com/mike-bourgeous/numo-narray-compat) allows us to continue using other gems that still depend on numo-narray directly.

Because I was working from a laptop, I also added minimal support for audio I/O on macOS using jackd.

# Tasks

- [x] Switch back to a release version of numo-narray-alt if/when the fix for double-yield is released