### PR TITLE
Easier wavetable generation and performance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GIT
 PATH
   remote: .
   specs:
-    mb-sound (0.11.2.1.usegit)
+    mb-sound (0.12.0.usegit)
       builder (~> 3.2.4)
       cmath (~> 1.0.0)
       csv (~> 3.3, >= 3.3.3)

--- a/bin/synths/wavetable_bass.rb
+++ b/bin/synths/wavetable_bass.rb
@@ -11,8 +11,16 @@ DETUNE_RANGE = (2 ** -DETUNE_SEMIS)..(2 ** DETUNE_SEMIS)
 PORTAMENTO_TIME = 0.1 # TODO: control with midi CC for portamento
 
 MB::U.headline('Loading wavetables...')
-synthwave = MB::Sound::Wavetable.load_wavetable('sounds/drums.flac', slices: 10)
-shaperwave = MB::Sound::Wavetable.load_wavetable('sounds/synth0.flac', slices: 10)
+synthwave = MB::Sound::Wavetable.sort(
+  MB::Sound::Wavetable.normalize(
+    MB::Sound::Wavetable.load_wavetable('sounds/drums.flac', slices: 10)
+  )
+)
+shaperwave = MB::Sound::Wavetable.sort(
+  MB::Sound::Wavetable.normalize(
+    MB::Sound::Wavetable.load_wavetable('sounds/synth0.flac', slices: 10)
+  )
+)
 
 MB::Sound.synth_script { |input|
   MB::U.headline('Building synth...')

--- a/ext/mb/sound/fast_wavetable/fast_wavetable.c
+++ b/ext/mb/sound/fast_wavetable/fast_wavetable.c
@@ -1,6 +1,6 @@
 /*
  * Low-level implementation of wavetable sampling.
- * (C)2025 Mike Bourgeous
+ * (C)2025-2026 Mike Bourgeous
  */
 #include <samplerate.h>
 
@@ -26,6 +26,15 @@ enum wrapping_mode {
 	MODE_ZERO,
 	MODE_CLAMP,
 };
+
+// Behaves like Ruby's % operator instead of fmod
+// Wraps X to be between 0 and Y
+// TODO: dedupe static functions with other files
+static inline double fwrap(double x, double y)
+{
+	// this could instead be fmod(x, y) + y if x is negative
+	return x - y * floor(x / y);
+}
 
 // Returns C enum for the wrapping mode of the given Ruby symbol, or raises an
 // error if it's not valid.
@@ -193,7 +202,8 @@ static VALUE ruby_cubic_interp(VALUE self, VALUE y_1, VALUE y0, VALUE y1, VALUE 
 // Port of Ruby outer_linear and inner_lookup.
 static double outer_linear(float *wavetable, size_t rows, size_t columns, double number, double phase, enum wrapping_mode wrap)
 {
-	double frow = (number >= 0 ? fmod(number, 1) : fmod(number, 1) + 1) * rows;
+	double maxnum = (double)rows / (double)(rows - 1);
+	double frow = fwrap(number, maxnum) * (rows - 1);
 	ssize_t row1 = (ssize_t)floor(frow) % rows;
 	ssize_t row2 = (row1 + 1) % rows;
 	ssize_t offset1 = columns * row1;
@@ -243,7 +253,8 @@ static VALUE ruby_outer_linear(VALUE self, VALUE wavetable, VALUE number, VALUE 
 // Cubic interpolated 2D lookup.
 static double outer_cubic(float *wavetable, size_t rows, size_t columns, double number, double phase, enum wrapping_mode wrap)
 {
-	double frow = (number >= 0 ? fmod(number, 1) : fmod(number, 1) + 1) * rows;
+	double maxnum = (double)rows / (double)(rows - 1);
+	double frow = fwrap(number, maxnum) * (rows - 1);
 	ssize_t row1 = (ssize_t)floor(frow) % rows;
 	ssize_t row2 = (row1 + 1) % rows;
 	ssize_t offset1 = columns * row1;

--- a/ext/mb/sound/fast_wavetable/fast_wavetable.c
+++ b/ext/mb/sound/fast_wavetable/fast_wavetable.c
@@ -200,6 +200,7 @@ static VALUE ruby_cubic_interp(VALUE self, VALUE y_1, VALUE y0, VALUE y1, VALUE 
 
 // Interpolated 2D lookup.
 // Port of Ruby outer_linear and inner_lookup.
+// Phase ranges from -1..1 for a full single wave cycle.
 static double outer_linear(float *wavetable, size_t rows, size_t columns, double number, double phase, enum wrapping_mode wrap)
 {
 	double frow = fwrap(number * (rows - 1), rows);
@@ -209,7 +210,7 @@ static double outer_linear(float *wavetable, size_t rows, size_t columns, double
 	ssize_t offset2 = columns * row2;
 	double rowratio = frow - row1;
 
-	double fcol = (phase + 1) / 2 * columns;
+	double fcol = (phase + 1) / 2 * (columns - 1);
 	ssize_t col1 = (ssize_t)floor(fcol);
 	ssize_t col2 = col1 + 1;
 	double colratio = fcol - col1;
@@ -250,6 +251,7 @@ static VALUE ruby_outer_linear(VALUE self, VALUE wavetable, VALUE number, VALUE 
 }
 
 // Cubic interpolated 2D lookup.
+// Phase ranges from -1..1 for a full single wave cycle.
 static double outer_cubic(float *wavetable, size_t rows, size_t columns, double number, double phase, enum wrapping_mode wrap)
 {
 	double frow = fwrap(number * (rows - 1), rows);
@@ -259,7 +261,7 @@ static double outer_cubic(float *wavetable, size_t rows, size_t columns, double 
 	ssize_t offset2 = columns * row2;
 	double rowratio = frow - row1;
 
-	double fcol = (phase + 1) / 2 * columns;
+	double fcol = (phase + 1) / 2 * (columns - 1);
 	ssize_t col1 = floor(fcol);
 	double colratio = fcol - col1;
 

--- a/ext/mb/sound/fast_wavetable/fast_wavetable.c
+++ b/ext/mb/sound/fast_wavetable/fast_wavetable.c
@@ -202,8 +202,7 @@ static VALUE ruby_cubic_interp(VALUE self, VALUE y_1, VALUE y0, VALUE y1, VALUE 
 // Port of Ruby outer_linear and inner_lookup.
 static double outer_linear(float *wavetable, size_t rows, size_t columns, double number, double phase, enum wrapping_mode wrap)
 {
-	double maxnum = (double)rows / (double)(rows - 1);
-	double frow = fwrap(number, maxnum) * (rows - 1);
+	double frow = fwrap(number * (rows - 1), rows);
 	ssize_t row1 = (ssize_t)floor(frow) % rows;
 	ssize_t row2 = (row1 + 1) % rows;
 	ssize_t offset1 = columns * row1;
@@ -253,8 +252,7 @@ static VALUE ruby_outer_linear(VALUE self, VALUE wavetable, VALUE number, VALUE 
 // Cubic interpolated 2D lookup.
 static double outer_cubic(float *wavetable, size_t rows, size_t columns, double number, double phase, enum wrapping_mode wrap)
 {
-	double maxnum = (double)rows / (double)(rows - 1);
-	double frow = fwrap(number, maxnum) * (rows - 1);
+	double frow = fwrap(number * (rows - 1), rows);
 	ssize_t row1 = (ssize_t)floor(frow) % rows;
 	ssize_t row2 = (row1 + 1) % rows;
 	ssize_t offset1 = columns * row1;

--- a/lib/mb/sound/graph_node.rb
+++ b/lib/mb/sound/graph_node.rb
@@ -41,6 +41,9 @@ module MB
     # TODO: In-line method to create a meter?
     #
     # TODO: Document methods that nodes must implement or override
+    #
+    # TODO: Split methods in this module into groups and/or related classes
+    # (e.g. #wavetable could go into GraphNode::Wavetable)
     module GraphNode
       include Nameable
       include Traversable
@@ -707,6 +710,14 @@ module MB
       #
       # +:wavetable+ - A 2D NArray to use as the wavetable.
       # +:number+ - A GraphNode or Numeric to control wave number.
+      # +:lookup+ - Interpolation mode (noisy :linear or cleaner :cubic).
+      # +:wrap+ - A wrapping mode constant, or a MIDI value.
+      #
+      # See Wavetable#initialize.
+      #
+      # Example:
+      #     # Wavetable oscillator
+      #     midi.tone.ramp.wavetable(wavetable: t, number: midi.cc(1))
       def wavetable(wavetable:, number:, lookup: :cubic, wrap: :wrap)
         number = number.constant if number.is_a?(Numeric)
         phase = self

--- a/lib/mb/sound/graph_node/wavetable.rb
+++ b/lib/mb/sound/graph_node/wavetable.rb
@@ -11,6 +11,20 @@ module MB
         include GraphNode
         include GraphNode::SampleRateHelper
 
+        # Valid values for the constructor's :wrap parameter.
+        WRAP_MODES = [
+          :wrap,
+          :bounce,
+          :clamp,
+          :zero
+        ]
+
+        # Valid values for the constructor's :lookup parameter.
+        LOOKUP_MODES = [
+          :linear,
+          :cubic
+        ]
+
         # The 2D Numo::NArray wavetable data used for sampling.
         attr_reader :table
 
@@ -22,14 +36,25 @@ module MB
 
         # Creates a new wavetable node.
         #
+        # The output of the MIDI value node for +:wrap+ will be scaled from its
+        # original range to cover the range of wrapping modes, without
+        # blending.
+        #
         # +:wavetable+ - A 2D Numo::NArray with time as columns and waves as
         #                rows, the filename of a previously saved wavetable, or
         #                a Hash of args to MB::Sound::Wavetable.load_wavetable.
         # +:number+ - A GraphNode to control the wave number (e.g. `3.constant`).
         # +:phase+ - A GraphNode to control the wave phase (e.g. `120.hz.ramp.at(1)`).
+        # +:lookup+ - Interpolation mode (:cubic or :linear).
+        # +:wrap+ - Wrapping mode (:wrap, :clamp, :bounce, :zero).  This can
+        #           also be a MIDI value node to allow changing modes on the fly.
         def initialize(wavetable:, number:, phase:, sample_rate:, lookup:, wrap:)
           raise 'Number must be a GraphNode' unless number.is_a?(GraphNode)
           raise 'Phase must be a GraphNode' unless phase.is_a?(GraphNode)
+          raise 'Lookup mode must be :linear or :cubic' unless LOOKUP_MODES.include?(lookup)
+          unless WRAP_MODES.include?(wrap) || wrap.is_a?(MB::Sound::GraphNode::MidiDsl::MidiValue)
+            raise 'Wrapping mode must be a symbol or a MIDI node'
+          end
 
           case wavetable
           when Hash
@@ -42,7 +67,7 @@ module MB
 
           else
             unless wavetable.is_a?(Numo::NArray) && wavetable.ndim == 2
-              raise 'Wavetable must be a 2D NArray or a wavetable filename' unless wavetable.ndim == 2
+              raise 'Wavetable must be a 2D NArray, Hash of load_wavetable arguments, or a wavetable filename'
             end
           end
 
@@ -72,8 +97,22 @@ module MB
           rho = MB::M.zpad(rho, count) if rho.length < count
           phi = MB::M.zpad(phi, count) if phi.length < count
 
-          # TODO: parameters for lookup mode and wrapping mode
-          ::MB::Sound::Wavetable.wavetable_lookup(wavetable: @table, number: rho, phase: phi, lookup: @lookup, wrap: @wrap)
+          case @wrap
+          when Symbol
+            wrap = @wrap
+
+          else
+            # MIDI-controlled wrapping mode
+            # TODO: allow the value range to select a subset of wrapping modes?
+            # TODO: allow any graph node and treat a range of 0..1 as the index range, with wrapping?
+            data = @wrap.sample(count)
+            return nil if data.nil? || data.empty?
+            index = MB::M.scale(data[-1], @wrap.range || (0..1), 0..WRAP_MODES.length).floor
+            index = WRAP_MODES.length - 1 if index >= WRAP_MODES.length
+            wrap = WRAP_MODES[index]
+          end
+
+          ::MB::Sound::Wavetable.wavetable_lookup(wavetable: @table, number: rho, phase: phi, lookup: @lookup, wrap: wrap)
         end
       end
     end

--- a/lib/mb/sound/io_methods.rb
+++ b/lib/mb/sound/io_methods.rb
@@ -362,10 +362,6 @@ module MB
           raise "Unsupported output type: #{output_type.inspect}"
         end
 
-        # Make sure the cache key corresponds to the actual buffer size, as
-        # sometimes an input will not accept a requested buffer size.
-        info[:buffer_size] = o.buffer_size
-
         @outputs[info] = o
 
         o

--- a/lib/mb/sound/version.rb
+++ b/lib/mb/sound/version.rb
@@ -1,5 +1,5 @@
 module MB
   module Sound
-    VERSION = "0.11.2.1.usegit"
+    VERSION = "0.12.0.usegit"
   end
 end

--- a/lib/mb/sound/wavetable.rb
+++ b/lib/mb/sound/wavetable.rb
@@ -140,8 +140,11 @@ module MB
       # 48kHz.
       #
       # The +:from+ and +:to+ parameters may be anything that MB::M.interp can
-      # interpolate.  The interpolated value and a base Tone with period
-      # +:length+ samples will be yielded to the block.
+      # interpolate.  Interpolation uses the smoothstep curve; use the :curve
+      # parameter to change this.
+      #
+      # The block will receive the interpolated value for the current step and
+      # a Tone object with a period of +:length+ samples.
       #
       # If the block returns a Numo::NArray, then that will be appended to the
       # wavetable.
@@ -149,10 +152,13 @@ module MB
       # If the block returns a Graph, then it will be sampled for +:length+
       # samples 3 times (to allow for filter stabilization) with the last tone
       # cycle appended to the wavetable (-(length*3/2)...-(length/2)).
-      def self.generate(steps: 10, from: 0, to: 1, length: 2048, center: false, sort: false, normalize: true)
+      #
+      # The :center, :sort, and :normalize parameters enable or disable
+      # post-processing by the method of the same name.
+      def self.generate(steps: 10, from: 0, to: 1, length: 2048, center: false, sort: false, normalize: true, fade_edges: true, curve: MB::M.method(:smoothstep))
         table = Array.new(steps) { |i|
           tone = (48000.0 / length).hz.at(1).with_phase(Math::PI)
-          val = MB::M.interp(from, to, i.to_f / (steps - 1), func: MB::M.method(:smoothstep))
+          val = MB::M.interp(from, to, i.to_f / (steps - 1), func: curve)
 
           ret = yield val, tone
           case ret
@@ -174,9 +180,10 @@ module MB
 
         table = normalize(table) if normalize
         table = sort(table) if sort
-        table = center(table) if center
 
-        # TODO: crossfade edges?
+        table = fade_edges(table) if fade_edges && center
+        table = center(table) if center
+        table = fade_edges(table) if fade_edges
 
         table.not_inplace!
       end
@@ -186,6 +193,42 @@ module MB
         fade = MB::FastSound.smootherstep_buf(Numo::SFloat.zeros(clip.length))
         fade = 1 - fade.inplace unless fade_in
         clip.inplace * fade.not_inplace!
+      end
+
+      # Blends the edges of each entry in +table+ to temper clicks for waves
+      # that aren't perfectly periodic or have discontinuities at the edge.
+      #
+      # Fades the first and last 1/64th of the buffer, with a minimum fade of 4
+      # samples.  Doesn't modify tables shorter than 8 samples.
+      def self.fade_edges(table)
+        raise 'Wavetable must be a 2D Numo::NArray' unless table.is_a?(Numo::NArray) && table.ndim == 2
+
+        rows, cols = table.shape
+
+        return table if cols < 8
+
+        table = table.dup unless table.inplace?
+
+        fade_cols = cols / 64
+        fade_cols = 4 if fade_cols < 4
+
+        fade_buf = MB::FastSound.smootherstep_buf(Numo::SFloat.zeros(fade_cols * 2))
+        fade_in_buf = (fade_buf[fade_cols..-1].inplace! * 2 - 1).not_inplace!
+        fade_out_buf = (1 - fade_buf[0...fade_cols].inplace! * 2).not_inplace!
+
+        rows.times do |row|
+          wave = table[row, nil]
+
+          intro = wave[0...fade_cols].inplace!
+          outro = wave[-fade_cols..-1].inplace!
+
+          mid = intro[0] + outro[-1]
+
+          intro * fade_in_buf + Numo::SFloat.linspace(0, mid, fade_cols + 2)[1..-2]
+          outro * fade_out_buf + Numo::SFloat.linspace(mid, 0, fade_cols)
+        end
+
+        table
       end
 
       # Creates a new wavetable that blends each row in the given +wavetable+

--- a/lib/mb/sound/wavetable.rb
+++ b/lib/mb/sound/wavetable.rb
@@ -135,6 +135,52 @@ module MB
         center(buf.reshape(slices, period_samples).inplace!).not_inplace!
       end
 
+      # Calls a block +:steps+ times to generate a wavetable by passing
+      # interpolating parameters to the block.  Sample rate is assumed to be
+      # 48kHz.
+      #
+      # The +:from+ and +:to+ parameters may be anything that MB::M.interp can
+      # interpolate.  The interpolated value and a base Tone with period
+      # +:length+ samples will be yielded to the block.
+      #
+      # If the block returns a Numo::NArray, then that will be appended to the
+      # wavetable.
+      #
+      # If the block returns a Graph, then it will be sampled for +:length+
+      # samples 3 times (to allow for filter stabilization) with the last tone
+      # cycle appended to the wavetable (-(length*3/2)...-(length/2)).
+      def self.generate(steps: 10, from: 0, to: 1, length: 2048, center: false, sort: false, normalize: true)
+        table = Array.new(steps) { |i|
+          tone = (48000.0 / length).hz.at(1).with_phase(Math::PI)
+          val = MB::M.interp(from, to, i.to_f / (steps - 1), func: MB::M.method(:smoothstep))
+
+          ret = yield val, tone
+          case ret
+          when Numo::NArray
+            raise "Wave length must be #{length} samples" unless ret.shape == [2048]
+            ret
+
+          when GraphNode
+            ret.sample(length)
+            ret.sample(length)
+            ret.sample(length)
+
+          else
+            raise "Unsupported wavetable entry: #{ret.inspect}"
+          end
+        }
+
+        table = Numo::SFloat.cast(table).inplace!
+
+        table = normalize(table) if normalize
+        table = sort(table) if sort
+        table = center(table) if center
+
+        # TODO: crossfade edges?
+
+        table.not_inplace!
+      end
+
       # Fades +clip+ in or out in-place.  For .make_wavetable.
       def self.fade(clip, fade_in)
         fade = MB::FastSound.smootherstep_buf(Numo::SFloat.zeros(clip.length))
@@ -220,6 +266,9 @@ module MB
       # the middle of the buffer.  Returns the existing wavetable if it was
       # marked as in-place, or a copy if it wasn't.  Raises an error if there
       # is no zero crossing (could be caused by silence, DC offset).
+      #
+      # TODO: find the closest zero crossing to the existing center in either
+      # direction?
       def self.center(wavetable)
         raise 'Wavetable must be a 2D Numo::NArray' unless wavetable.is_a?(Numo::NArray) && wavetable.ndim == 2
 
@@ -234,7 +283,7 @@ module MB
             zc_index = 0
           end
 
-          raise "No zero crossing found for row #{row}" unless zc_index
+          raise "No zero crossing found for row #{row} (min/max: #{wave.minmax})" unless zc_index
 
           wavetable[row, nil] = MB::M.rol(wave, zc_index - wave.length / 2)
         end

--- a/lib/mb/sound/wavetable.rb
+++ b/lib/mb/sound/wavetable.rb
@@ -141,7 +141,7 @@ module MB
       #
       # The +:from+ and +:to+ parameters may be anything that MB::M.interp can
       # interpolate.  Interpolation uses the smoothstep curve; use the :curve
-      # parameter to change this.
+      # parameter to change this (nil or ->{it} will be linear).
       #
       # The block will receive the interpolated value for the current step and
       # a Tone object with a period of +:length+ samples.
@@ -155,6 +155,13 @@ module MB
       #
       # The :center, :sort, and :normalize parameters enable or disable
       # post-processing by the method of the same name.
+      #
+      # Examples:
+      #     # Square to saw
+      #     MB::Sound::Wavetable.generate(fade_edges: false) { |v, _t| MB::M.safe_power(Numo::SFloat.linspace(-1, 1, 2048), v) }
+      #
+      #     # Harmonics
+      #     MB::Sound::Wavetable.generate(from: 2, to: 11, curve: nil) { |v, t| t + (t.frequency * v).hz }
       def self.generate(steps: 10, from: 0, to: 1, length: 2048, center: false, sort: false, normalize: true, fade_edges: true, curve: MB::M.method(:smoothstep))
         table = Array.new(steps) { |i|
           tone = (48000.0 / length).hz.at(1).with_phase(Math::PI)

--- a/lib/mb/sound/wavetable.rb
+++ b/lib/mb/sound/wavetable.rb
@@ -220,16 +220,12 @@ module MB
         wavetable
       end
 
-      # TODO: functions to sort wavetables by brightness, etc.?
-      # TODO: functions to shuffle and stretch wavetables?
+      # TODO: functions to shuffle and stretch/interpolate wavetables?
       # TODO: functions for spectral changes to wavetables?
       # TODO: mip-mapped or note-range wavetables
       # TODO: midi/realtime control of wavetable wrapping mode?
       # TODO: blend between wrapping modes by output
       # TODO: warp between wrapping modes by blending lookup indices?
-      # FIXME: having wave 1.0 wrap fully around to the start makes control
-      # difficult; it would be more musically playable if 1.0 was the last wave
-      # in the table
       # FIXME: make it super easy to play the full cycle including cubic
       # overshoot, and make the areas around that more musical somehow (getting
       # clicking and very sharp waves if the phase is off just a tiny bit); it
@@ -307,10 +303,10 @@ module MB
       # +:wavetable+, as opposed to linear interpolation used by
       # #outer_linear_ruby.
       def self.outer_cubic_ruby(wavetable:, number:, phase:, wrap:)
-        rows = wavetable.shape[0].to_f
-        cols = wavetable.shape[1].to_f
+        rows = wavetable.shape[0]
+        cols = wavetable.shape[1]
 
-        frow = (number * rows) % rows
+        frow = (number * (rows - 1)) % rows
         row1 = frow.floor
         row2 = row1 + 1
         row1 %= rows
@@ -322,7 +318,7 @@ module MB
         vtop = MB::M.cubic_lookup(wavetable[row1, nil], fcol, mode: wrap)
         vbot = MB::M.cubic_lookup(wavetable[row2, nil], fcol, mode: wrap)
 
-        # TODO: smoothstep between waves?
+        # TODO: smoothstep or cubic between waves?
         vbot * rowratio + vtop * (1.0 - rowratio)
       end
 
@@ -331,7 +327,7 @@ module MB
         wave_count = wavetable.shape[0]
         sample_count = wavetable.shape[1]
 
-        frow = (number * wave_count) % wave_count
+        frow = (number * (wave_count - 1)) % wave_count
         row1 = frow.floor
         row2 = row1 + 1
         row1 %= wave_count

--- a/lib/mb/sound/wavetable.rb
+++ b/lib/mb/sound/wavetable.rb
@@ -128,15 +128,11 @@ module MB
           max = MB::M.max(middle.abs.max, -80.db)
           middle = middle / max
 
-          # Rotate phase to put positive zero crossing at center
-          zc_index = MB::M.find_zero_crossing(middle)
-          middle = MB::M.rol(middle, zc_index - middle.length / 2) if zc_index
-
           buf[offset...(offset + period_samples)] = middle
           offset += period_samples
         end
 
-        buf.reshape(slices, period_samples)
+        center(buf.reshape(slices, period_samples).inplace!).not_inplace!
       end
 
       # Fades +clip+ in or out in-place.  For .make_wavetable.
@@ -215,6 +211,32 @@ module MB
           data -= data.mean
           rowmax = MB::M.max(-80.db, data.abs.max)
           wavetable[row, nil] = data * (max / rowmax)
+        end
+
+        wavetable
+      end
+
+      # Performs per-row centering to place each wave's first zero crossing in
+      # the middle of the buffer.  Returns the existing wavetable if it was
+      # marked as in-place, or a copy if it wasn't.  Raises an error if there
+      # is no zero crossing (could be caused by silence, DC offset).
+      def self.center(wavetable)
+        raise 'Wavetable must be a 2D Numo::NArray' unless wavetable.is_a?(Numo::NArray) && wavetable.ndim == 2
+
+        wavetable = wavetable.dup unless wavetable.inplace?
+
+        for row in 0...wavetable.shape[0]
+          wave = wavetable[row, nil]
+
+          zc_index = MB::M.find_zero_crossing(wave)
+          if zc_index.nil? && wave[-1] < 0 && wave[0] >= 0
+            # TODO: should find_zero_crossing wrap around like this?
+            zc_index = 0
+          end
+
+          raise "No zero crossing found for row #{row}" unless zc_index
+
+          wavetable[row, nil] = MB::M.rol(wave, zc_index - wave.length / 2)
         end
 
         wavetable

--- a/lib/mb/sound/wavetable.rb
+++ b/lib/mb/sound/wavetable.rb
@@ -213,6 +213,13 @@ module MB
         # FIXME: make this look right for all of these:
         # t = MB::Sound::Wavetable.generate { |v, t| t.fm(v.constant) }
         # t = MB::Sound::Wavetable.generate(steps: 100, normalize: false) { |v, t| Numo::SFloat.zeros(2048).fill(v) }
+        #
+        # Idea: subtract a smoothstep or linear element across the fade range,
+        # preserving some higher frequencies but ending at the same value as
+        # the beginning.  This might be made idempotent(?)
+        #
+        # Idea 2: ignore the midpoint value and just blend between the end
+        # values
 
         rows, cols = table.shape
 

--- a/lib/mb/sound/wavetable.rb
+++ b/lib/mb/sound/wavetable.rb
@@ -445,7 +445,7 @@ module MB
         row2 %= rows
         rowratio = frow - row1
 
-        fcol = (phase + 1) / 2 * cols
+        fcol = (phase + 1) / 2 * (cols - 1)
 
         vtop = MB::M.cubic_lookup(wavetable[row1, nil], fcol, mode: wrap)
         vbot = MB::M.cubic_lookup(wavetable[row2, nil], fcol, mode: wrap)
@@ -466,7 +466,7 @@ module MB
         row2 %= wave_count
         rowratio = frow - row1
 
-        fcol = (phase + 1) / 2 * sample_count
+        fcol = (phase + 1) / 2 * (sample_count - 1)
         col1 = fcol.floor
         col2 = col1 + 1
         colratio = fcol - col1

--- a/lib/mb/sound/wavetable.rb
+++ b/lib/mb/sound/wavetable.rb
@@ -210,6 +210,10 @@ module MB
       def self.fade_edges(table)
         raise 'Wavetable must be a 2D Numo::NArray' unless table.is_a?(Numo::NArray) && table.ndim == 2
 
+        # FIXME: make this look right for all of these:
+        # t = MB::Sound::Wavetable.generate { |v, t| t.fm(v.constant) }
+        # t = MB::Sound::Wavetable.generate(steps: 100, normalize: false) { |v, t| Numo::SFloat.zeros(2048).fill(v) }
+
         rows, cols = table.shape
 
         return table if cols < 8
@@ -229,10 +233,10 @@ module MB
           intro = wave[0...fade_cols].inplace!
           outro = wave[-fade_cols..-1].inplace!
 
-          mid = intro[0] + outro[-1]
+          mid = 0.5 * (intro[0] + outro[-1])
 
-          intro * fade_in_buf + Numo::SFloat.linspace(0, mid, fade_cols + 2)[1..-2]
-          outro * fade_out_buf + Numo::SFloat.linspace(mid, 0, fade_cols)
+          intro * fade_in_buf + mid * (1 - fade_in_buf)
+          outro * fade_out_buf + mid * (1 - fade_out_buf)
         end
 
         table

--- a/spec/ext/mb/sound/fast_wavetable_spec.rb
+++ b/spec/ext/mb/sound/fast_wavetable_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe(MB::Sound::FastWavetable, aggregate_failures: true) do
   describe '.outer_linear' do
     it 'can retrieve a value from a wavetable' do
       expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 0, 0 * 2 - 1, :wrap)).to eq(0)
-      expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 1, 0.5 * 2 - 1, :wrap)).to eq(2)
+      expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 1, 1 * 2 - 1, :wrap)).to eq(2)
       expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 1, 0 * 2 - 1, :wrap)).to eq(-1)
     end
   end
@@ -12,7 +12,7 @@ RSpec.describe(MB::Sound::FastWavetable, aggregate_failures: true) do
   describe '.outer_cubic' do
     it 'can retrieve a value from a wavetable' do
       expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 0, 0 * 2 - 1, :wrap)).to eq(0)
-      expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 1, 0.5 * 2 - 1, :wrap)).to eq(2)
+      expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 1, 1 * 2 - 1, :wrap)).to eq(2)
       expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 1, 0 * 2 - 1, :wrap)).to eq(-1)
     end
   end
@@ -20,7 +20,7 @@ RSpec.describe(MB::Sound::FastWavetable, aggregate_failures: true) do
   describe '.wavetable_lookup' do
     let(:table) { Numo::SFloat[[0, 1, -2], [-1, 2, -3]] }
     let(:number) { Numo::SFloat[0, 0.5, 1] }
-    let(:phase) { Numo::SFloat[0, 1.0 / 3.0, 1] * 2 - 1 }
+    let(:phase) { Numo::SFloat[0, 1.0 / 2.0, 3.0 / 2.0] * 2 - 1 }
 
     it 'can retrieve values from a wavetable using narrays and linear interpolation' do
       expect(MB::Sound::FastWavetable.wavetable_lookup(table, number, phase, :linear, :wrap)).to all_be_within(1e-6).of_array(Numo::SFloat[0, 1.5, -1])

--- a/spec/ext/mb/sound/fast_wavetable_spec.rb
+++ b/spec/ext/mb/sound/fast_wavetable_spec.rb
@@ -4,34 +4,34 @@ RSpec.describe(MB::Sound::FastWavetable, aggregate_failures: true) do
   describe '.outer_linear' do
     it 'can retrieve a value from a wavetable' do
       expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 0, 0 * 2 - 1, :wrap)).to eq(0)
-      expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 0.5, 0.5 * 2 - 1, :wrap)).to eq(2)
-      expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 0.5, 0 * 2 - 1, :wrap)).to eq(-1)
+      expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 1, 0.5 * 2 - 1, :wrap)).to eq(2)
+      expect(MB::Sound::FastWavetable.outer_linear(Numo::SFloat[[0, 1], [-1, 2]], 1, 0 * 2 - 1, :wrap)).to eq(-1)
     end
   end
 
   describe '.outer_cubic' do
     it 'can retrieve a value from a wavetable' do
       expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 0, 0 * 2 - 1, :wrap)).to eq(0)
-      expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 0.5, 0.5 * 2 - 1, :wrap)).to eq(2)
-      expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 0.5, 0 * 2 - 1, :wrap)).to eq(-1)
+      expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 1, 0.5 * 2 - 1, :wrap)).to eq(2)
+      expect(MB::Sound::FastWavetable.outer_cubic(Numo::SFloat[[0, 1], [-1, 2]], 1, 0 * 2 - 1, :wrap)).to eq(-1)
     end
   end
 
   describe '.wavetable_lookup' do
     let(:table) { Numo::SFloat[[0, 1, -2], [-1, 2, -3]] }
-    let(:number) { Numo::SFloat[0, 0.5, 0.5] }
+    let(:number) { Numo::SFloat[0, 0.5, 1] }
     let(:phase) { Numo::SFloat[0, 1.0 / 3.0, 1] * 2 - 1 }
 
     it 'can retrieve values from a wavetable using narrays and linear interpolation' do
-      expect(MB::Sound::FastWavetable.wavetable_lookup(table, number, phase, :linear, :wrap)).to all_be_within(1e-6).of_array(Numo::SFloat[0, 2, -1])
+      expect(MB::Sound::FastWavetable.wavetable_lookup(table, number, phase, :linear, :wrap)).to all_be_within(1e-6).of_array(Numo::SFloat[0, 1.5, -1])
     end
 
     it 'can retrieve values from a wavetable using narrays and cubic interpolation' do
-      expect(MB::Sound::FastWavetable.wavetable_lookup(table, number, phase, :cubic, :wrap)).to all_be_within(1e-6).of_array(Numo::SFloat[0, 2, -1])
+      expect(MB::Sound::FastWavetable.wavetable_lookup(table, number, phase, :cubic, :wrap)).to all_be_within(1e-6).of_array(Numo::SFloat[0, 1.5, -1])
     end
 
     it 'can bounce oob' do
-      expect(MB::Sound::FastWavetable.wavetable_lookup(table, number, phase, :cubic, :bounce)).to all_be_within(1e-6).of_array(Numo::SFloat[0, 2, 2])
+      expect(MB::Sound::FastWavetable.wavetable_lookup(table, number, phase, :cubic, :bounce)).to all_be_within(1e-6).of_array(Numo::SFloat[0, 1.5, 2])
     end
   end
 

--- a/spec/lib/mb/sound/graph_node/wavetable_spec.rb
+++ b/spec/lib/mb/sound/graph_node/wavetable_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe(MB::Sound::GraphNode::Wavetable) do
     end
 
     describe ':wrap parameter' do
-      let(:phase) { MB::Sound::ArrayInput.new(data: [ Numo::SFloat[0, 1.0 / 4.0, 1, 5.0 / 4.0, -1.0 / 4.0] * 2 - 1 ]) }
+      let(:phase) { MB::Sound::ArrayInput.new(data: [ Numo::SFloat[0, 1.0 / 3.0, 4.0 / 3.0, 5.0 / 3.0, -1.0 / 3.0] * 2 - 1 ]) }
       let(:table) { Numo::SFloat[[1, -2, 3, -4]] }
 
       it 'defaults to :wrap' do
@@ -66,7 +66,7 @@ RSpec.describe(MB::Sound::GraphNode::Wavetable) do
     end
 
     describe ':lookup parameter' do
-      let(:interp_phase) { MB::Sound::ArrayInput.new(data: [ Numo::SFloat[0, 1.0 / 8.0, 7.0 / 8.0, 9.0 / 8.0, -1.0 / 4.0] * 2 - 1 ]) }
+      let(:interp_phase) { MB::Sound::ArrayInput.new(data: [ Numo::SFloat[0, 1.0 / 6.0, 7.0 / 6.0, 9.0 / 6.0, -1.0 / 3.0] * 2 - 1 ]) }
       let(:table) { Numo::SFloat[[1, -2, 3, -4]] }
 
       it 'defaults to cubic' do
@@ -91,7 +91,7 @@ RSpec.describe(MB::Sound::GraphNode::Wavetable) do
 
   describe '#sample' do
     it 'treats the upstream data as the phase source' do
-      phase = MB::Sound::ArrayInput.new(data: [Numo::SFloat.linspace(0, 2, 13) * 2 - 1])
+      phase = MB::Sound::ArrayInput.new(data: [Numo::SFloat.linspace(0, 12.0/5.0, 13) * 2 - 1])
       number = 0.constant
       expect(phase.wavetable(wavetable: data, number: number).sample(12)).to all_be_within(1e-6).of_array(
         Numo::SFloat[1, -1, 1, 1, -1, -1, 1, -1, 1, 1, -1, -1]
@@ -99,7 +99,7 @@ RSpec.describe(MB::Sound::GraphNode::Wavetable) do
     end
 
     it 'changes wave number based on the number source' do
-      phase = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 0, 1.0 / 6.0, 1.0 / 6.0] * 2 - 1], repeat: true)
+      phase = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 0, 1.0 / 5.0, 1.0 / 5.0] * 2 - 1], repeat: true)
       number = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 1, 2, 2.5]], repeat: true)
       expect(phase.wavetable(wavetable: data, number: number).sample(8)).to all_be_within(1e-6).of_array(
         Numo::SFloat[1, 0, -1, 0, 1, 0, -1, 0]
@@ -107,7 +107,7 @@ RSpec.describe(MB::Sound::GraphNode::Wavetable) do
     end
 
     it 'changes wave number based on the number source using linspace' do
-      phase = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 0, 1.0 / 6.0, 1.0 / 6.0] * 2 - 1], repeat: true)
+      phase = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 0, 1.0 / 5.0, 1.0 / 5.0] * 2 - 1], repeat: true)
       number = MB::Sound::ArrayInput.new(data: [Numo::SFloat.linspace(0, 8, 9)])
       expect(phase.wavetable(wavetable: data, number: number).sample(8)).to all_be_within(1e-6).of_array(
         Numo::SFloat[1, 0, -1, 1, 1, 0, -1, 1]

--- a/spec/lib/mb/sound/graph_node/wavetable_spec.rb
+++ b/spec/lib/mb/sound/graph_node/wavetable_spec.rb
@@ -100,15 +100,15 @@ RSpec.describe(MB::Sound::GraphNode::Wavetable) do
 
     it 'changes wave number based on the number source' do
       phase = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 0, 1.0 / 6.0, 1.0 / 6.0] * 2 - 1], repeat: true)
-      number = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 0.5, 1, 1.5]], repeat: true)
+      number = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 1, 2, 2.5]], repeat: true)
       expect(phase.wavetable(wavetable: data, number: number).sample(8)).to all_be_within(1e-6).of_array(
-        Numo::SFloat[1, 0, -1, 1, 1, 0, -1, 1]
+        Numo::SFloat[1, 0, -1, 0, 1, 0, -1, 0]
       )
     end
 
     it 'changes wave number based on the number source using linspace' do
       phase = MB::Sound::ArrayInput.new(data: [Numo::SFloat[0, 0, 1.0 / 6.0, 1.0 / 6.0] * 2 - 1], repeat: true)
-      number = MB::Sound::ArrayInput.new(data: [Numo::SFloat.linspace(0, 4, 9)])
+      number = MB::Sound::ArrayInput.new(data: [Numo::SFloat.linspace(0, 8, 9)])
       expect(phase.wavetable(wavetable: data, number: number).sample(8)).to all_be_within(1e-6).of_array(
         Numo::SFloat[1, 0, -1, 1, 1, 0, -1, 1]
       )

--- a/spec/lib/mb/sound/wavetable_spec.rb
+++ b/spec/lib/mb/sound/wavetable_spec.rb
@@ -346,6 +346,16 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.2 * 2 - 1, wrap: :zero).round(6)).to eq(0)
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.21 * 2 - 1, wrap: :zero).round(6)).to eq(0)
       end
+
+      MB::Sound::GraphNode::Wavetable::WRAP_MODES.each do |w|
+        it "returns the original wave value for phase -1 with #{w}" do
+          expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -1, wrap: w).round(6)).to eq(1)
+        end
+
+        it "returns the original wave value for phase 1 with #{w}" do
+          expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1, wrap: w).round(6)).to eq(5)
+        end
+      end
     end
 
     shared_examples_for 'linear lookup' do |m|

--- a/spec/lib/mb/sound/wavetable_spec.rb
+++ b/spec/lib/mb/sound/wavetable_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
-  let(:table) {
+  let (:one_table) {
+    Numo::SFloat[[5, -3, 3, -1, 2]]
+  }
+
+  let (:table) {
     Numo::SFloat[
       [1, 2, 3, 4, 5],
       [5, -3, 3, -1, 2],
@@ -33,6 +37,19 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
       result = MB::Sound.read(name, metadata_out: metadata)[0]
       expect(result).to all_be_within(1e-6).of_array(Numo::SFloat[0.5, -0.5, 0, 0.1, 0.2, -0.3, -0.75, 0.25, 0.75])
       expect(metadata[:mb_sound_wavetable_period]&.to_i).to eq(3)
+    end
+
+    it 'can write a single-row wavetable to disk' do
+      name = 'tmp/single_wavetable_save.flac'
+      FileUtils.mkdir_p('tmp/')
+      File.unlink(name) if File.exist?(name)
+
+      MB::Sound::Wavetable.save_wavetable(name, one_table / 5)
+
+      metadata = {}
+      result = MB::Sound.read(name, metadata_out: metadata)[0]
+      expect(result).to all_be_within(1e-6).of_array(one_table.reshape(5) / 5)
+      expect(metadata[:mb_sound_wavetable_period]&.to_i).to eq(5)
     end
   end
 
@@ -89,6 +106,8 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
         [-2.33333, 0.666667, -2, 0, -3.66667]
       ])
     end
+
+    pending 'works with steps set to 1'
   end
 
   describe '.normailze' do
@@ -155,6 +174,8 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
       zc_table.inplace!
       expect { MB::Sound::Wavetable.center(zc_table) }.to change { zc_table.to_a }
     end
+
+    pending 'works with a single-row wavetable'
   end
 
   context 'array lookup' do
@@ -203,6 +224,45 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
       it 'can zero cubic oob' do
         result = MB::Sound::Wavetable.send(m, wavetable: table, number: oob_number, phase: oob_phase, lookup: :cubic, wrap: :zero)
         expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[1.5, -1, -0.625, 1.1875, -0.24609375, 0.0703125])
+      end
+
+      context 'with a single-row wavetable' do
+        #XXX
+      let(:number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0] }
+      let(:phase) { Numo::SFloat[0, 0.4, 0.6, 1.2, 0.1] * 2 - 1 }
+      let(:oob_number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0, 5.0 / 2.0] }
+      let(:oob_phase) { Numo::SFloat[0.1, 0.6, -0.1, 0.9, 1.05, -0.25] * 2 - 1 }
+
+        it 'can wrap linear oob' do
+          result = MB::Sound::Wavetable.send(m, wavetable: one_table, number: number, phase: phase, lookup: :linear, wrap: :wrap)
+          expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[5, 3, -1, -3, 1])
+        end
+
+        it 'can wrap cubic oob' do
+          result = MB::Sound::Wavetable.send(m, wavetable: one_table, number: number, phase: phase, lookup: :cubic, wrap: :wrap)
+          expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[5, 3, -1, -3, 0.8125])
+        end
+
+        it 'can bounce linear oob' do
+          result = MB::Sound::Wavetable.send(m, wavetable: one_table, number: oob_number, phase: oob_phase, lookup: :linear, wrap: :bounce)
+          expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[1, -1, 1, 0.5, 0, -1.5])
+        end
+
+        it 'can bounce cubic oob' do
+          result = MB::Sound::Wavetable.send(m, wavetable: one_table, number: oob_number, phase: oob_phase, lookup: :cubic, wrap: :bounce)
+          expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[1.125, -1, 1.125, 0.437501, -0.257814, -2.25])
+        end
+
+        it 'ignores number' do
+          result = MB::Sound::Wavetable.send(m, wavetable: one_table, number: Numo::SFloat.linspace(-2.72, 3.14, 6), phase: oob_phase.dup, lookup: :cubic, wrap: :bounce)
+          expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[1.125, -1, 1.125, 0.437501, -0.257814, -2.25])
+
+          result = MB::Sound::Wavetable.send(m, wavetable: one_table, number: Numo::SFloat.zeros(6), phase: oob_phase.dup, lookup: :cubic, wrap: :bounce)
+          expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[1.125, -1, 1.125, 0.437501, -0.257814, -2.25])
+
+          result = MB::Sound::Wavetable.send(m, wavetable: one_table, number: Numo::SFloat.ones(6), phase: oob_phase.dup, lookup: :cubic, wrap: :bounce)
+          expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[1.125, -1, 1.125, 0.437501, -0.257814, -2.25])
+        end
       end
     end
 

--- a/spec/lib/mb/sound/wavetable_spec.rb
+++ b/spec/lib/mb/sound/wavetable_spec.rb
@@ -75,6 +75,62 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
     end
   end
 
+  describe '.center' do
+    let (:zc_table) {
+      Numo::SFloat[
+        [2, 3, -1, -2, -3, 1],
+        [0, 1, 2, 3, 4, -1],
+      ]
+    }
+
+    let (:zc_expected) {
+      Numo::SFloat[
+        [-1, -2, -3, 1, 2, 3],
+        [3, 4, -1, 0, 1, 2],
+      ]
+    }
+
+    let (:zc_odd) {
+      Numo::SFloat[
+        [2, 3, -1, -2, -3, 1, 1],
+        [0, 1, 2, 3, 4, -1, -2],
+      ]
+    }
+
+    let (:odd_expected) {
+      Numo::SFloat[
+        [-1, -2, -3, 1, 1, 2, 3],
+        [4, -1, -2, 0, 1, 2, 3],
+      ]
+    }
+
+    it 'centers a wavetable that has zero crossings' do
+      expect(MB::Sound::Wavetable.center(zc_table)).to eq(zc_expected)
+    end
+
+    it 'works with odd lengths' do
+      expect(MB::Sound::Wavetable.center(zc_odd)).to eq(odd_expected)
+    end
+
+    it 'raises an error if there is no zero crossing' do
+      expect { MB::Sound::Wavetable.center(table) }.to raise_error(/crossing.*row 0/)
+      expect { MB::Sound::Wavetable.center(zc_table + 2) }.to raise_error(/crossing.*row 1/)
+    end
+
+    it 'does not modify the table if it is not in place' do
+      expect { MB::Sound::Wavetable.center(zc_table) }.not_to change { zc_table }
+    end
+
+    it 'can work in place' do
+      zc_odd.inplace!
+      expect(MB::Sound::Wavetable.center(zc_odd)).to eql(zc_odd)
+
+      expect { MB::Sound::Wavetable.center(zc_table) }.not_to change { zc_table.to_a }
+      zc_table.inplace!
+      expect { MB::Sound::Wavetable.center(zc_table) }.to change { zc_table.to_a }
+    end
+  end
+
   context 'array lookup' do
     shared_examples_for 'wavetable lookup' do |m|
       let(:number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0] }

--- a/spec/lib/mb/sound/wavetable_spec.rb
+++ b/spec/lib/mb/sound/wavetable_spec.rb
@@ -38,7 +38,31 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
 
   pending '.make_wavetable'
 
-  pending '.generate'
+  describe '.generate' do
+    let (:fm_table) { MB::Sound::Wavetable.generate { |v, t| t.fm(t.frequency * (1 + v)) } }
+
+    it 'defaults to 10x2048' do
+      expect(fm_table.shape).to eq([10, 2048])
+      expect(fm_table.min.round(6)).to eq(-1)
+      expect(fm_table.max.round(6)).to eq(1)
+    end
+
+    it 'can generate different sizes' do
+      expect(MB::Sound::Wavetable.generate(steps: 71, length: 147) { |_v, t| t }.shape).to eq([71, 147])
+    end
+
+    it 'can assemble NArrays' do
+      table = MB::Sound::Wavetable.generate(normalize: false, fade_edges: false) { |v, _t| Numo::SFloat.linspace(-v, v, 2048) }
+      expect(table[-1, nil].min.round(6)).to eq(-1)
+      expect(table[-1, nil].max.round(6)).to eq(1)
+      expect(table[1, nil].min.round(6)).to eq(-MB::M.smoothstep(1.0 / 9.0).round(6))
+      expect(table[1, nil].max.round(6)).to eq(MB::M.smoothstep(1.0 / 9.0).round(6))
+    end
+
+    pending ':curve'
+
+    pending 'post-processing parameters'
+  end
 
   describe '.blur' do
     it 'blends adjacent rows' do

--- a/spec/lib/mb/sound/wavetable_spec.rb
+++ b/spec/lib/mb/sound/wavetable_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
 
   pending '.make_wavetable'
 
+  pending '.generate'
+
   describe '.blur' do
     it 'blends adjacent rows' do
       blurred = MB::Sound::Wavetable.blur(table, 1)

--- a/spec/lib/mb/sound/wavetable_spec.rb
+++ b/spec/lib/mb/sound/wavetable_spec.rb
@@ -181,10 +181,10 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
   context 'array lookup' do
     shared_examples_for 'wavetable lookup' do |m|
       let(:number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0] }
-      let(:phase) { Numo::SFloat[0, 0.4, 0.6, 1.2, 0.1] * 2 - 1 }
+      let(:phase) { Numo::SFloat[0, 2.0 / 4.0, 3.0 / 4.0, 6.0 / 4.0, 1.0 / 8.0] * 2 - 1 }
 
       let(:oob_number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0, 5.0 / 2.0] }
-      let(:oob_phase) { Numo::SFloat[0.1, 0.6, -0.1, 0.9, 1.05, -0.25] * 2 - 1 }
+      let(:oob_phase) { Numo::SFloat[1.0 / 8.0, 3.0 / 4.0, -1.0 / 8.0, 9.0 / 8.0, 21.0 / 16.0, -5.0 / 16.0] * 2 - 1 }
 
       it 'can perform lookups based on arrays with linear interpolation' do
         result = MB::Sound::Wavetable.send(m, wavetable: table, number: number, phase: phase, lookup: :linear, wrap: :wrap)
@@ -227,12 +227,6 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
       end
 
       context 'with a single-row wavetable' do
-        #XXX
-      let(:number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0] }
-      let(:phase) { Numo::SFloat[0, 0.4, 0.6, 1.2, 0.1] * 2 - 1 }
-      let(:oob_number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0, 5.0 / 2.0] }
-      let(:oob_phase) { Numo::SFloat[0.1, 0.6, -0.1, 0.9, 1.05, -0.25] * 2 - 1 }
-
         it 'can wrap linear oob' do
           result = MB::Sound::Wavetable.send(m, wavetable: one_table, number: number, phase: phase, lookup: :linear, wrap: :wrap)
           expect(result).to all_be_within(1e-5).of_array(Numo::SFloat[5, 3, -1, -3, 1])
@@ -289,10 +283,10 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
 
       it 'can retrieve exact columns in the wavetable' do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.2 * 2 - 1, wrap: :wrap).round(6)).to eq(2)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.4 * 2 - 1, wrap: :wrap).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.6 * 2 - 1, wrap: :wrap).round(6)).to eq(4)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.8 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.25 * 2 - 1, wrap: :wrap).round(6)).to eq(2)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.5 * 2 - 1, wrap: :wrap).round(6)).to eq(3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.75 * 2 - 1, wrap: :wrap).round(6)).to eq(4)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.0 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
       end
 
       it 'wraps around rows' do
@@ -305,46 +299,46 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
       end
 
       it 'can interpolate between rows' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 0.8 * 2 - 1, wrap: :wrap).round(6)).to eq(3.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.6 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 1.0 * 2 - 1, wrap: :wrap).round(6)).to eq(3.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.75 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
       end
 
       it 'can blend straight line columns regardless of interpolation type' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(2.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 3.0 / 8.0 * 2 - 1, wrap: :wrap).round(6)).to eq(2.5)
       end
 
       it 'wraps around columns with :wrap' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 2 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -1 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.2 * 2 - 1, wrap: :wrap).round(6)).to eq(2)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.2 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.25 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 2.5 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -1.25 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.5 * 2 - 1, wrap: :wrap).round(6)).to eq(2)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.25 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
       end
 
       it 'can reflect exactly with :bounce' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1 * 2 - 1, wrap: :bounce).round(6)).to eq(4)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 2 * 2 - 1, wrap: :bounce).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -1 * 2 - 1, wrap: :bounce).round(6)).to eq(4)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.2 * 2 - 1, wrap: :bounce).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.2 * 2 - 1, wrap: :bounce).round(6)).to eq(-3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.25 * 2 - 1, wrap: :bounce).round(6)).to eq(4)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 2.5 * 2 - 1, wrap: :bounce).round(6)).to eq(3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -1.25 * 2 - 1, wrap: :bounce).round(6)).to eq(4)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.5 * 2 - 1, wrap: :bounce).round(6)).to eq(3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.25 * 2 - 1, wrap: :bounce).round(6)).to eq(-3)
       end
 
       it 'can clamp with :clamp' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.41 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.4 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.2 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.2 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.21 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.51 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.5 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.25 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.25 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.5 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.51 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
       end
 
       it 'can set to zero with :zero' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.41 * 2 - 1, wrap: :zero).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.4 * 2 - 1, wrap: :zero).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.2 * 2 - 1, wrap: :zero).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1 * 2 - 1, wrap: :zero).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.2 * 2 - 1, wrap: :zero).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.21 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.51 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.5 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.25 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.25 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.5 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.51 * 2 - 1, wrap: :zero).round(6)).to eq(0)
       end
 
       MB::Sound::GraphNode::Wavetable::WRAP_MODES.each do |w|
@@ -360,89 +354,89 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
 
     shared_examples_for 'linear lookup' do |m|
       it 'can interpolate between columns' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.125 * 2 - 1, wrap: :wrap).round(6)).to eq(1.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.125 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
       end
 
       it 'can interpolate between rows and columns' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 0.7 * 2 - 1, wrap: :wrap).round(6)).to eq(2.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(0.25)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 0.875 * 2 - 1, wrap: :wrap).round(6)).to eq(2.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.375 * 2 - 1, wrap: :wrap).round(6)).to eq(0.25)
       end
 
       it 'can wrap between columns with :wrap' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(4.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :wrap).round(6)).to eq(3.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.375 * 2 - 1, wrap: :wrap).round(6)).to eq(4.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.125 * 2 - 1, wrap: :wrap).round(6)).to eq(3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.125 * 2 - 1, wrap: :wrap).round(6)).to eq(3.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.375 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
       end
 
       it 'can reflect between columns with :bounce' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.3 * 2 - 1, wrap: :bounce).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :bounce).round(6)).to eq(0.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.375 * 2 - 1, wrap: :bounce).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.125 * 2 - 1, wrap: :bounce).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.125 * 2 - 1, wrap: :bounce).round(6)).to eq(0.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.375 * 2 - 1, wrap: :bounce).round(6)).to eq(1)
       end
 
       it 'can interpolate to zero with :zero' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.3 * 2 - 1, wrap: :zero).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.1 * 2 - 1, wrap: :zero).round(6)).to eq(2.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :zero).round(6)).to eq(-2)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.375 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.125 * 2 - 1, wrap: :zero).round(6)).to eq(2.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.125 * 2 - 1, wrap: :zero).round(6)).to eq(-2)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.375 * 2 - 1, wrap: :zero).round(6)).to eq(0)
       end
 
       it 'can clamp between columns with :clamp' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.1 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.05 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.85 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.9 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.1 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.125 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -1.0 / 16.0 * 2 - 1, wrap: :clamp).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 17.0 / 16.0 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.125 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.375 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
       end
     end
 
     shared_examples_for 'cubic lookup' do |m|
       # Values computed manually using previously tested cubic interpolation function
       it 'can interpolate between columns' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.1875)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(0.8125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.125 * 2 - 1, wrap: :wrap).round(6)).to eq(1.1875)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.125 * 2 - 1, wrap: :wrap).round(6)).to eq(0.8125)
       end
 
       it 'can interpolate between rows and columns' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 0.7 * 2 - 1, wrap: :wrap).round(6)).to eq(2.4375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(0.09375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 0.875 * 2 - 1, wrap: :wrap).round(6)).to eq(2.4375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.375 * 2 - 1, wrap: :wrap).round(6)).to eq(0.09375)
       end
 
       it 'can wrap between columns with :wrap' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(4.8125)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :wrap).round(6)).to eq(4.1875)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :wrap).round(6)).to eq(0.8125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.375 * 2 - 1, wrap: :wrap).round(6)).to eq(4.8125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.125 * 2 - 1, wrap: :wrap).round(6)).to eq(3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.125 * 2 - 1, wrap: :wrap).round(6)).to eq(4.1875)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.375 * 2 - 1, wrap: :wrap).round(6)).to eq(0.8125)
       end
 
       it 'can reflect between columns with :bounce' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.3 * 2 - 1, wrap: :bounce).round(6)).to eq(-0.25)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1.125)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :bounce).round(6)).to eq(0.4375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1.1875)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.375 * 2 - 1, wrap: :bounce).round(6)).to eq(-0.25)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.125 * 2 - 1, wrap: :bounce).round(6)).to eq(1.125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.125 * 2 - 1, wrap: :bounce).round(6)).to eq(0.4375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.375 * 2 - 1, wrap: :bounce).round(6)).to eq(1.1875)
       end
 
       it 'can interpolate to zero with :zero' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.3 * 2 - 1, wrap: :zero).round(6)).to eq(-0.3125)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.1 * 2 - 1, wrap: :zero).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.1 * 2 - 1, wrap: :zero).round(6)).to eq(0.9375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 0.7 * 2 - 1, wrap: :zero).round(6)).to eq(-0.5625)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :zero).round(6)).to eq(-2.4375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.05 * 2 - 1, wrap: :zero).round(6)).to eq(0.28125)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :zero).round(6)).to eq(0.25)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.375 * 2 - 1, wrap: :zero).round(6)).to eq(-0.3125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.125 * 2 - 1, wrap: :zero).round(6)).to eq(3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.125 * 2 - 1, wrap: :zero).round(6)).to eq(0.9375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 0.875 * 2 - 1, wrap: :zero).round(6)).to eq(-0.5625)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.125 * 2 - 1, wrap: :zero).round(6)).to eq(-2.4375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 21.0 / 16.0 * 2 - 1, wrap: :zero).round(6)).to eq(0.28125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.375 * 2 - 1, wrap: :zero).round(6)).to eq(0.25)
       end
 
       it 'can clamp between columns with :clamp' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.1 * 2 - 1, wrap: :clamp).round(6)).to eq(0.9375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.05 * 2 - 1, wrap: :clamp).round(6)).to eq(0.9296875.round(6))
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.1 * 2 - 1, wrap: :clamp).round(6)).to eq(0.625)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.7 * 2 - 1, wrap: :clamp).round(6)).to eq(4.5625)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.85 * 2 - 1, wrap: :clamp).round(6)).to eq(5.0703125.round(6))
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.9 * 2 - 1, wrap: :clamp).round(6)).to eq(5.0625)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.1 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.125 * 2 - 1, wrap: :clamp).round(6)).to eq(0.9375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -1.0 / 16.0 * 2 - 1, wrap: :clamp).round(6)).to eq(0.9296875.round(6))
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.125 * 2 - 1, wrap: :clamp).round(6)).to eq(0.625)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.875 * 2 - 1, wrap: :clamp).round(6)).to eq(4.5625)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 17.0 / 16.0 * 2 - 1, wrap: :clamp).round(6)).to eq(5.0703125.round(6))
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.125 * 2 - 1, wrap: :clamp).round(6)).to eq(5.0625)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.375 * 2 - 1, wrap: :clamp).round(6)).to eq(5)
       end
     end
 

--- a/spec/lib/mb/sound/wavetable_spec.rb
+++ b/spec/lib/mb/sound/wavetable_spec.rb
@@ -77,10 +77,10 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
 
   context 'array lookup' do
     shared_examples_for 'wavetable lookup' do |m|
-      let(:number) { Numo::SFloat[0, 1.0 / 3.0, 2.0 / 3.0, -2.0 / 3.0, 1.0 / 6.0] }
+      let(:number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0] }
       let(:phase) { Numo::SFloat[0, 0.4, 0.6, 1.2, 0.1] * 2 - 1 }
 
-      let(:oob_number) { Numo::SFloat[0, 1.0 / 3.0, 2.0 / 3.0, -2.0 / 3.0, 1.0 / 6.0, 5.0 / 3.0] }
+      let(:oob_number) { Numo::SFloat[0, 1.0 / 2.0, 2.0 / 2.0, -2.0 / 2.0, 1.0 / 4.0, 5.0 / 2.0] }
       let(:oob_phase) { Numo::SFloat[0.1, 0.6, -0.1, 0.9, 1.05, -0.25] * 2 - 1 }
 
       it 'can perform lookups based on arrays with linear interpolation' do
@@ -141,8 +141,8 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
     shared_examples_for 'exact lookup' do |m|
       it 'can retrieve exact rows in the wavetable' do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 3.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(-1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(-1)
       end
 
       it 'can retrieve exact columns in the wavetable' do
@@ -154,15 +154,17 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
       end
 
       it 'wraps around rows' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 4.0 / 3.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: -1.0 / 3.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(-1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 2.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 6.0 / 2.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 4.0 / 2.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: -1.0 / 2.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(-1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: -9.0 / 2.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: -11.0 / 2.0, phase: 0 * 2 - 1, wrap: :wrap).round(6)).to eq(5)
       end
 
       it 'can interpolate between rows' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 6.0, phase: 0.8 * 2 - 1, wrap: :wrap).round(6)).to eq(3.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 6.0, phase: 0.6 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 0.8 * 2 - 1, wrap: :wrap).round(6)).to eq(3.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.6 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
       end
 
       it 'can blend straight line columns regardless of interpolation type' do
@@ -182,7 +184,7 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 2 * 2 - 1, wrap: :bounce).round(6)).to eq(3)
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -1 * 2 - 1, wrap: :bounce).round(6)).to eq(4)
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 1.2 * 2 - 1, wrap: :bounce).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.2 * 2 - 1, wrap: :bounce).round(6)).to eq(-3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.2 * 2 - 1, wrap: :bounce).round(6)).to eq(-3)
       end
 
       it 'can clamp with :clamp' do
@@ -207,33 +209,33 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
     shared_examples_for 'linear lookup' do |m|
       it 'can interpolate between columns' do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
       end
 
       it 'can interpolate between rows and columns' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 6.0, phase: 0.7 * 2 - 1, wrap: :wrap).round(6)).to eq(2.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 6.0, phase: 0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(0.25)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 0.7 * 2 - 1, wrap: :wrap).round(6)).to eq(2.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(0.25)
       end
 
       it 'can wrap between columns with :wrap' do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(4.5)
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0.9 * 2 - 1, wrap: :wrap).round(6)).to eq(3.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 1.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :wrap).round(6)).to eq(3.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.0)
       end
 
       it 'can reflect between columns with :bounce' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.3 * 2 - 1, wrap: :bounce).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0.9 * 2 - 1, wrap: :bounce).round(6)).to eq(0.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 1.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.3 * 2 - 1, wrap: :bounce).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :bounce).round(6)).to eq(0.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1)
       end
 
       it 'can interpolate to zero with :zero' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.3 * 2 - 1, wrap: :zero).round(6)).to eq(0)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.1 * 2 - 1, wrap: :zero).round(6)).to eq(2.5)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 3.0, phase: 0.9 * 2 - 1, wrap: :zero).round(6)).to eq(-2)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 3.0, phase: 1.1 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.3 * 2 - 1, wrap: :zero).round(6)).to eq(0)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.1 * 2 - 1, wrap: :zero).round(6)).to eq(2.5)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :zero).round(6)).to eq(-2)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :zero).round(6)).to eq(0)
       end
 
       it 'can clamp between columns with :clamp' do
@@ -249,42 +251,42 @@ RSpec.describe(MB::Sound::Wavetable, aggregate_failures: true) do
       # Values computed manually using previously tested cubic interpolation function
       it 'can interpolate between columns' do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(1.1875)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(0.8125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(0.8125)
       end
 
       it 'can interpolate between rows and columns' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 6.0, phase: 0.7 * 2 - 1, wrap: :wrap).round(6)).to eq(2.4375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 6.0, phase: 0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(0.09375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 4.0, phase: 0.7 * 2 - 1, wrap: :wrap).round(6)).to eq(2.4375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 3.0 / 4.0, phase: 0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(0.09375)
       end
 
       it 'can wrap between columns with :wrap' do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.3 * 2 - 1, wrap: :wrap).round(6)).to eq(4.8125)
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.1 * 2 - 1, wrap: :wrap).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0.9 * 2 - 1, wrap: :wrap).round(6)).to eq(4.1875)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 1.1 * 2 - 1, wrap: :wrap).round(6)).to eq(0.8125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :wrap).round(6)).to eq(4.1875)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :wrap).round(6)).to eq(0.8125)
       end
 
       it 'can reflect between columns with :bounce' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.3 * 2 - 1, wrap: :bounce).round(6)).to eq(-0.25)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1.125)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0.9 * 2 - 1, wrap: :bounce).round(6)).to eq(0.4375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 1.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1.1875)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.3 * 2 - 1, wrap: :bounce).round(6)).to eq(-0.25)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1.125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :bounce).round(6)).to eq(0.4375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :bounce).round(6)).to eq(1.1875)
       end
 
       it 'can interpolate to zero with :zero' do
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.3 * 2 - 1, wrap: :zero).round(6)).to eq(-0.3125)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: -0.1 * 2 - 1, wrap: :zero).round(6)).to eq(3)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0.1 * 2 - 1, wrap: :zero).round(6)).to eq(0.9375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 3.0, phase: 0.7 * 2 - 1, wrap: :zero).round(6)).to eq(-0.5625)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 3.0, phase: 0.9 * 2 - 1, wrap: :zero).round(6)).to eq(-2.4375)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 3.0, phase: 1.05 * 2 - 1, wrap: :zero).round(6)).to eq(0.28125)
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 3.0, phase: 1.1 * 2 - 1, wrap: :zero).round(6)).to eq(0.25)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.3 * 2 - 1, wrap: :zero).round(6)).to eq(-0.3125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: -0.1 * 2 - 1, wrap: :zero).round(6)).to eq(3)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.1 * 2 - 1, wrap: :zero).round(6)).to eq(0.9375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 0.7 * 2 - 1, wrap: :zero).round(6)).to eq(-0.5625)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 0.9 * 2 - 1, wrap: :zero).round(6)).to eq(-2.4375)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.05 * 2 - 1, wrap: :zero).round(6)).to eq(0.28125)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 2.0 / 2.0, phase: 1.1 * 2 - 1, wrap: :zero).round(6)).to eq(0.25)
       end
 
       it 'can clamp between columns with :clamp' do
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.1 * 2 - 1, wrap: :clamp).round(6)).to eq(0.9375)
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: -0.05 * 2 - 1, wrap: :clamp).round(6)).to eq(0.9296875.round(6))
-        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 3.0, phase: 0.1 * 2 - 1, wrap: :clamp).round(6)).to eq(0.625)
+        expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 1.0 / 2.0, phase: 0.1 * 2 - 1, wrap: :clamp).round(6)).to eq(0.625)
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.7 * 2 - 1, wrap: :clamp).round(6)).to eq(4.5625)
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.85 * 2 - 1, wrap: :clamp).round(6)).to eq(5.0703125.round(6))
         expect(MB::Sound::Wavetable.send(m, wavetable: table, number: 0, phase: 0.9 * 2 - 1, wrap: :clamp).round(6)).to eq(5.0625)

--- a/spec/lib/mb/sound_spec.rb
+++ b/spec/lib/mb/sound_spec.rb
@@ -29,37 +29,4 @@ RSpec.describe MB::Sound do
       expect(env.release_time).to eq(0.4)
     end
   end
-
-  describe 'noise' do
-    it 'creates a noise generator node' do
-      n = MB::Sound.noise.sample(48000)
-      expect(n.mean.round(3)).to eq(0)
-      expect(n.min.round(3)).to eq(-0.1)
-      expect(n.max.round(3)).to eq(0.1)
-
-      histogram = {}
-      n.each do |v|
-        next if v.abs.round(2) == 0.1 # the 0.1 bin only has contribution from below, not above, so ignore it
-
-        histogram[v.round(2)] ||= 0
-        histogram[v.round(2)] += 1
-      end
-
-      expect(histogram.values.max.to_f / histogram.values.min).to be_between(0.75, 1.33)
-
-      diff = 2000.hz.ramp.generate(48000).diff
-      expect(diff.mean.round(3)).to eq(0)
-
-      diff_hist = {}
-      diff.each do |v|
-        next if v.abs.round(2) == 0.2
-
-        diff_hist[v.round(2)] ||= 0
-        diff_hist[v.round(2)] += 1
-      end
-
-      # A normal ramp wave will produce only two diff values, while noise will produce many
-      expect(diff.length).to be > 10
-    end
-  end
 end


### PR DESCRIPTION
This PR adds `MB::Sound::Wavetable.generate` to help generating wavetables based on interpolated parameters.  It also changes the meaning of wave number so that 0.0 is the first wave and 1.0 is the last wave (rather than 1.0 wrapping around).  This makes musical control with a fader easier, but breaks the 0-1 wrapping correspondence with wave phase.

- [x] Fix `:zero` wrapping mode when input is within `-1..1`: <img width="1030" height="309" alt="image" src="https://github.com/user-attachments/assets/79192bc1-7dde-4d61-9849-9d44fc37f5b7" />
    This may be due to the cubic interpolator seeing a `0` sample just beyond the edge.  Maybe adding a single fake clamped sample before the zeros would solve this.
