### PR TITLE
Use FFMPEG for audio output on Mac if Jack is not running.

### DIFF
--- a/lib/mb/sound/io_methods.rb
+++ b/lib/mb/sound/io_methods.rb
@@ -355,6 +355,9 @@ module MB
         when :alsa
           o = MB::Sound::AlsaOutput.new(device: device || 'default', sample_rate: sample_rate, channels: channels, buffer_size: buffer_size)
 
+        when :ffmpeg
+          o = MB::Sound::FFMPEGOutput.new('default', sample_rate: sample_rate, channels: channels, buffer_size: buffer_size, format: 'audiotoolbox')
+
         when :null
           o = MB::Sound::NullOutput.new(channels: channels, sample_rate: sample_rate, buffer_size: buffer_size)
 
@@ -397,7 +400,7 @@ module MB
               :jack
             end
           else
-            raise NotImplementedError, 'JackD is currently required on macOS'
+            :ffmpeg
           end
 
         else


### PR DESCRIPTION
RubyConf 2026 hack day